### PR TITLE
feat: adds the PATCH /orders/:id/status endpoint

### DIFF
--- a/api/cmd/migrate/migrations/20240915230043_add_orders_table.up.sql
+++ b/api/cmd/migrate/migrations/20240915230043_add_orders_table.up.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS orders (
     order_id SERIAL PRIMARY KEY,
     invoice_number VARCHAR(36) UNIQUE NOT NULL,
     total_price DECIMAL(12, 2) NOT NULL,
-    status order_status NOT NULL,
+    status order_status NOT NULL DEFAULT 'received',
     firstname VARCHAR(32) NOT NULL,
     lastname VARCHAR(32) NOT NULL,
     email VARCHAR(100) NOT NULL,

--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -226,6 +226,52 @@ const docTemplate = `{
                 }
             }
         },
+        "/orders/{order_id}/status": {
+            "patch": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Updates the status for a specific order by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Orders"
+                ],
+                "summary": "Update the status of an existing order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "order_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New order status",
+                        "name": "statusUpdate",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateOrderStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Message"
+                        }
+                    }
+                }
+            }
+        },
         "/socks": {
             "get": {
                 "description": "Returns a list of paginated socks sorted in descending order by created date",
@@ -781,6 +827,28 @@ const docTemplate = `{
                 "zipcode": {
                     "type": "string",
                     "maxLength": 10
+                }
+            }
+        },
+        "types.UpdateOrderStatusRequest": {
+            "type": "object",
+            "required": [
+                "message",
+                "newStatus"
+            ],
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "newStatus": {
+                    "type": "string",
+                    "enum": [
+                        "received",
+                        "shipped",
+                        "delivered",
+                        "canceled",
+                        "returned"
+                    ]
                 }
             }
         }

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -220,6 +220,52 @@
                 }
             }
         },
+        "/orders/{order_id}/status": {
+            "patch": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Updates the status for a specific order by ID",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Orders"
+                ],
+                "summary": "Update the status of an existing order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "order_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New order status",
+                        "name": "statusUpdate",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.UpdateOrderStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Message"
+                        }
+                    }
+                }
+            }
+        },
         "/socks": {
             "get": {
                 "description": "Returns a list of paginated socks sorted in descending order by created date",
@@ -775,6 +821,28 @@
                 "zipcode": {
                     "type": "string",
                     "maxLength": 10
+                }
+            }
+        },
+        "types.UpdateOrderStatusRequest": {
+            "type": "object",
+            "required": [
+                "message",
+                "newStatus"
+            ],
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "newStatus": {
+                    "type": "string",
+                    "enum": [
+                        "received",
+                        "shipped",
+                        "delivered",
+                        "canceled",
+                        "returned"
+                    ]
                 }
             }
         }

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -302,6 +302,22 @@ definitions:
     - street
     - zipcode
     type: object
+  types.UpdateOrderStatusRequest:
+    properties:
+      message:
+        type: string
+      newStatus:
+        enum:
+        - received
+        - shipped
+        - delivered
+        - canceled
+        - returned
+        type: string
+    required:
+    - message
+    - newStatus
+    type: object
 host: localhost:8080
 info:
   contact: {}
@@ -441,6 +457,35 @@ paths:
       security:
       - Bearer: []
       summary: Update the address of an existing order
+      tags:
+      - Orders
+  /orders/{order_id}/status:
+    patch:
+      consumes:
+      - application/json
+      description: Updates the status for a specific order by ID
+      parameters:
+      - description: Order ID
+        in: path
+        name: order_id
+        required: true
+        type: integer
+      - description: New order status
+        in: body
+        name: statusUpdate
+        required: true
+        schema:
+          $ref: '#/definitions/types.UpdateOrderStatusRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Message'
+      security:
+      - Bearer: []
+      summary: Update the status of an existing order
       tags:
       - Orders
   /socks:

--- a/api/types/payloads.go
+++ b/api/types/payloads.go
@@ -73,3 +73,8 @@ type UpdateAddressRequest struct {
 	State   string `json:"state" validate:"required,len=2,oneof=AL AK AZ AR CA CO CT DE FL GA HI ID IL IN IA KS KY LA ME MD MA MI MN MS MO MT NE NV NH NJ NM NY NC ND OH OK OR PA RI SC SD TN TX UT VT VA WA WV WI WY"`
 	Zipcode string `json:"zipcode" validate:"required,max=10"`
 }
+
+type UpdateOrderStatusRequest struct {
+	NewStatus string `json:"newStatus" validate:"required,oneof=received shipped delivered canceled returned"`
+	Message   string `json:"message" validate:"required"`
+}

--- a/api/types/stores.go
+++ b/api/types/stores.go
@@ -25,4 +25,6 @@ type OrderStore interface {
 	CountOrders() (total int, err error)
 	UpdateOrderAddress(orderID int, address UpdateAddressRequest, adminID int) error
 	OrderExistsByID(orderID int) (bool, error)
+	UpdateOrderStatus(orderID int, adminID int, newStatus string, message string) error
+	GetOrderStatusByID(orderID int) (status string, err error)
 }


### PR DESCRIPTION
## Description

Admins are now able to update the status of an order and provide a message.

## Changes

- Adds the `PATCH /orders/:id/status` endpoint
- Status updates are validated to ensure admins are not able to place an order in an invalid state (e.g. delivered -> received)
- Adds a default status to `orders` table: `received`

## Screenshots/demo

![image](https://github.com/user-attachments/assets/6f7875df-5636-4c42-b065-1069159653e7)

<img width="933" alt="image" src="https://github.com/user-attachments/assets/12b5eb23-921b-46d4-99e5-c2406425f114">


## Related issues

Closes #44 
