### PR TITLE
feat: adds GET /orders/:id/updates endpoint

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -272,6 +272,43 @@ const docTemplate = `{
                 }
             }
         },
+        "/orders/{order_id}/updates": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Retrieves all order updates for a particular order. Results are sorted descending by createdAt.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Orders"
+                ],
+                "summary": "Retrieve updates for an order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "order_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.OrderUpdate"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/socks": {
             "get": {
                 "description": "Returns a list of paginated socks sorted in descending order by created date",
@@ -584,6 +621,37 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "size": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.OrderUpdate": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdBy": {
+                    "$ref": "#/definitions/types.OrderUpdateCreator"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.OrderUpdateCreator": {
+            "type": "object",
+            "properties": {
+                "firstname": {
+                    "type": "string"
+                },
+                "lastname": {
+                    "type": "string"
+                },
+                "username": {
                     "type": "string"
                 }
             }

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -266,6 +266,43 @@
                 }
             }
         },
+        "/orders/{order_id}/updates": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Retrieves all order updates for a particular order. Results are sorted descending by createdAt.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Orders"
+                ],
+                "summary": "Retrieve updates for an order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "order_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.OrderUpdate"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/socks": {
             "get": {
                 "description": "Returns a list of paginated socks sorted in descending order by created date",
@@ -578,6 +615,37 @@
                     "type": "integer"
                 },
                 "size": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.OrderUpdate": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "createdBy": {
+                    "$ref": "#/definitions/types.OrderUpdateCreator"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.OrderUpdateCreator": {
+            "type": "object",
+            "properties": {
+                "firstname": {
+                    "type": "string"
+                },
+                "lastname": {
+                    "type": "string"
+                },
+                "username": {
                     "type": "string"
                 }
             }

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -119,6 +119,26 @@ definitions:
       size:
         type: string
     type: object
+  types.OrderUpdate:
+    properties:
+      createdAt:
+        type: string
+      createdBy:
+        $ref: '#/definitions/types.OrderUpdateCreator'
+      id:
+        type: integer
+      message:
+        type: string
+    type: object
+  types.OrderUpdateCreator:
+    properties:
+      firstname:
+        type: string
+      lastname:
+        type: string
+      username:
+        type: string
+    type: object
   types.OrdersPaginatedResponse:
     properties:
       items:
@@ -486,6 +506,30 @@ paths:
       security:
       - Bearer: []
       summary: Update the status of an existing order
+      tags:
+      - Orders
+  /orders/{order_id}/updates:
+    get:
+      description: Retrieves all order updates for a particular order. Results are
+        sorted descending by createdAt.
+      parameters:
+      - description: Order ID
+        in: path
+        name: order_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.OrderUpdate'
+            type: array
+      security:
+      - Bearer: []
+      summary: Retrieve updates for an order
       tags:
       - Orders
   /socks:

--- a/api/types/entities.go
+++ b/api/types/entities.go
@@ -65,10 +65,15 @@ type Contact struct {
 	Phone     *string `json:"phone"`
 }
 
-type LogOrderUpdate struct {
-	OrderUpdateID int       `json:"orderUpdateId"`
-	OrderID       int       `json:"orderId"`
-	AdminID       int       `json:"adminId"`
-	Message       string    `json:"message"`
-	CreatedAt     time.Time `json:"createdAt"`
+type OrderUpdate struct {
+	ID        int                `json:"id"`
+	CreatedBy OrderUpdateCreator `json:"createdBy"`
+	Message   string             `json:"message"`
+	CreatedAt time.Time          `json:"createdAt"`
+}
+
+type OrderUpdateCreator struct {
+	FirstName string `json:"firstname"`
+	LastName  string `json:"lastname"`
+	Username  string `json:"username"`
 }

--- a/api/types/stores.go
+++ b/api/types/stores.go
@@ -23,6 +23,7 @@ type OrderStore interface {
 	GetOrders(limit int, offset int, status string) ([]Order, error)
 	GetOrderItems(id int) ([]OrderItem, error)
 	CountOrders() (total int, err error)
+	GetOrderUpdates(orderID int) ([]OrderUpdate, error)
 	UpdateOrderAddress(orderID int, address UpdateAddressRequest, adminID int) error
 	OrderExistsByID(orderID int) (bool, error)
 	UpdateOrderStatus(orderID int, adminID int, newStatus string, message string) error


### PR DESCRIPTION
## Description

Admins are now able to get all of the updates for a particular order through the API.

## Changes

- /GET order/:id/updates endpoint created
- Swagger docs generated

## Screenshots/demo

<img width="1419" alt="image" src="https://github.com/user-attachments/assets/db725e95-845e-4fa4-add0-ec9660246e69">

## Related issues

Closes #46
