### PR TITLE
feat: adds the `POST /orders/:id/update` endpoint to create new order…

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -387,6 +387,50 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Creates a new update for an existing order.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Orders"
+                ],
+                "summary": "Creates an update for an order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "order_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New order update",
+                        "name": "address",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.CreateOrderUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Message"
+                        }
+                    }
+                }
             }
         },
         "/socks": {
@@ -595,6 +639,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "phone": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.CreateOrderUpdateRequest": {
+            "type": "object",
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "message": {
                     "type": "string"
                 }
             }

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -381,6 +381,50 @@
                         }
                     }
                 }
+            },
+            "post": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Creates a new update for an existing order.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Orders"
+                ],
+                "summary": "Creates an update for an order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "order_id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New order update",
+                        "name": "address",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/types.CreateOrderUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Message"
+                        }
+                    }
+                }
             }
         },
         "/socks": {
@@ -589,6 +633,17 @@
                     "type": "string"
                 },
                 "phone": {
+                    "type": "string"
+                }
+            }
+        },
+        "types.CreateOrderUpdateRequest": {
+            "type": "object",
+            "required": [
+                "message"
+            ],
+            "properties": {
+                "message": {
                     "type": "string"
                 }
             }

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -50,6 +50,13 @@ definitions:
       phone:
         type: string
     type: object
+  types.CreateOrderUpdateRequest:
+    properties:
+      message:
+        type: string
+    required:
+    - message
+    type: object
   types.CreateSockRequest:
     properties:
       sock:
@@ -576,6 +583,34 @@ paths:
       security:
       - Bearer: []
       summary: Retrieve updates for an order
+      tags:
+      - Orders
+    post:
+      consumes:
+      - application/json
+      description: Creates a new update for an existing order.
+      parameters:
+      - description: Order ID
+        in: path
+        name: order_id
+        required: true
+        type: integer
+      - description: New order update
+        in: body
+        name: address
+        required: true
+        schema:
+          $ref: '#/definitions/types.CreateOrderUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Message'
+      security:
+      - Bearer: []
+      summary: Creates an update for an order
       tags:
       - Orders
   /orders/invoice/{invoice_number}:

--- a/api/services/orders/order_store.go
+++ b/api/services/orders/order_store.go
@@ -2,6 +2,7 @@ package orders
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 
 	"github.com/sockify/sockify/types"
@@ -219,6 +220,27 @@ func (s *OrderStore) GetOrderUpdates(orderID int) ([]types.OrderUpdate, error) {
 	}
 
 	return updates, nil
+}
+
+func (s *OrderStore) CreateOrderUpdate(orderID int, adminID int, message string) error {
+	res, err := s.db.Exec(`
+    INSERT INTO order_updates (order_id, admin_id, message)
+    VALUES ($1, $2, $3)
+  `, orderID, adminID, message)
+
+	if err != nil {
+		return err
+	}
+
+	val, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if val == 0 {
+		return fmt.Errorf("no rows were affected")
+	}
+
+	return nil
 }
 
 func (s *OrderStore) UpdateOrderContact(orderID int, contact types.UpdateContactRequest, adminID int) error {

--- a/api/types/payloads.go
+++ b/api/types/payloads.go
@@ -85,3 +85,7 @@ type UpdateContactRequest struct {
 	Email     string `json:"email" validate:"required,email"`
 	Phone     string `json:"phone" validate:"required"`
 }
+
+type CreateOrderUpdateRequest struct {
+	Message string `json:"message" validate:"required"`
+}

--- a/api/types/stores.go
+++ b/api/types/stores.go
@@ -24,6 +24,7 @@ type OrderStore interface {
 	GetOrderItems(id int) ([]OrderItem, error)
 	CountOrders() (total int, err error)
 	GetOrderUpdates(orderID int) ([]OrderUpdate, error)
+	CreateOrderUpdate(orderID int, adminID int, message string) error
 	UpdateOrderAddress(orderID int, address UpdateAddressRequest, adminID int) error
 	OrderExistsByID(orderID int) (bool, error)
 	UpdateOrderStatus(orderID int, adminID int, newStatus string, message string) error


### PR DESCRIPTION
… updates

## Description

Within the UI, admins will be able to create manual updates for an order. Essentially, this would be if a customer calls and has a complain, the support specialist can leave a note on the order for future reference.

## Changes

- Adds the `POST /orders/:id/updates`

## Screenshots/demo

1. Post
![image](https://github.com/user-attachments/assets/01208a52-efb7-43f7-b300-958fbc17acbd)

2. Results & DB
![image](https://github.com/user-attachments/assets/049bf545-2df2-478d-a8db-95372249cd0b)

<img width="687" alt="image" src="https://github.com/user-attachments/assets/29c9ca96-f3fe-4f94-9810-1866556c388c">


## Related issues

Closes #60
