### PR TITLE
feat: adds the GET /orders/:order_id endpoint

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -214,6 +214,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/orders/{order_id}": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Retrieves all the details for a particular order.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Orders"
+                ],
+                "summary": "Retrieve details for an order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "order_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Order"
+                        }
+                    }
+                }
+            }
+        },
         "/orders/{order_id}/address": {
             "patch": {
                 "security": [

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -208,6 +208,40 @@
                 }
             }
         },
+        "/orders/{order_id}": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Retrieves all the details for a particular order.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Orders"
+                ],
+                "summary": "Retrieve details for an order",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Order ID",
+                        "name": "order_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Order"
+                        }
+                    }
+                }
+            }
+        },
         "/orders/{order_id}/address": {
             "patch": {
                 "security": [

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -473,6 +473,27 @@ paths:
       summary: Retrieve all orders
       tags:
       - Orders
+  /orders/{order_id}:
+    get:
+      description: Retrieves all the details for a particular order.
+      parameters:
+      - description: Order ID
+        in: path
+        name: order_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Order'
+      security:
+      - Bearer: []
+      summary: Retrieve details for an order
+      tags:
+      - Orders
   /orders/{order_id}/address:
     patch:
       consumes:

--- a/api/types/stores.go
+++ b/api/types/stores.go
@@ -21,6 +21,7 @@ type SockStore interface {
 
 type OrderStore interface {
 	GetOrders(limit int, offset int, status string) ([]Order, error)
+	GetOrderById(orderID int) (*Order, error)
 	GetOrderItems(id int) ([]OrderItem, error)
 	CountOrders() (total int, err error)
 	GetOrderUpdates(orderID int) ([]OrderUpdate, error)


### PR DESCRIPTION
## Description

Admins are now able to get a particular order's details by the `orderID`

## Changes

- Adds the `GET /orders/:order_id` endpoint

## Screenshots/demo

![image](https://github.com/user-attachments/assets/9e2dde7c-ca4e-4eec-a536-f7bb11ea768d)

## Related issues

Closes #43
