### PR TITLE
feat: adds `GET /admin/:admin_id` endpoint and updates UI

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -133,6 +133,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/admins/{admin_id}": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Retrieves all of an admins relevant information.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admins"
+                ],
+                "summary": "Get details of a specific admin",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Admin ID",
+                        "name": "admin_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Admin"
+                        }
+                    }
+                }
+            }
+        },
         "/orders": {
             "get": {
                 "security": [

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -127,6 +127,40 @@
                 }
             }
         },
+        "/admins/{admin_id}": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "description": "Retrieves all of an admins relevant information.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Admins"
+                ],
+                "summary": "Get details of a specific admin",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Admin ID",
+                        "name": "admin_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/types.Admin"
+                        }
+                    }
+                }
+            }
+        },
         "/orders": {
             "get": {
                 "security": [

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -397,6 +397,27 @@ paths:
       summary: Get all admins.
       tags:
       - Admins
+  /admins/{admin_id}:
+    get:
+      description: Retrieves all of an admins relevant information.
+      parameters:
+      - description: Admin ID
+        in: path
+        name: admin_id
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/types.Admin'
+      security:
+      - Bearer: []
+      summary: Get details of a specific admin
+      tags:
+      - Admins
   /admins/login:
     post:
       consumes:

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -82,6 +82,12 @@ func WithJWTAuth(store types.AdminStore, nextHandler http.HandlerFunc) http.Hand
 			return
 		}
 
+		if admin == nil {
+			log.Printf("no admin found with id: %v", userID)
+			permissionUnauthorized(w)
+			return
+		}
+
 		ctx := r.Context()
 		ctx = context.WithValue(ctx, UserKey, admin.ID)
 		r = r.WithContext(ctx)

--- a/api/services/admin/handler.go
+++ b/api/services/admin/handler.go
@@ -3,6 +3,7 @@ package admin
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gorilla/mux"
@@ -25,6 +26,7 @@ func (h *Handler) RegisterRoutes(router *mux.Router) {
 	router.HandleFunc("/admins/login", h.handleAdminLogin).Methods(http.MethodPost)
 	router.HandleFunc("/admins/register", middleware.WithJWTAuth(h.store, h.handleAdminRegister)).Methods(http.MethodPost)
 	router.HandleFunc("/admins", middleware.WithJWTAuth(h.store, h.handleGetAdmins)).Methods(http.MethodGet)
+	router.HandleFunc("/admins/{admin_id}", middleware.WithJWTAuth(h.store, h.handleGetAdmin)).Methods(http.MethodGet)
 }
 
 // @Summary Get all admins.
@@ -51,6 +53,38 @@ func (h *Handler) handleGetAdmins(w http.ResponseWriter, r *http.Request) {
 		Limit:  limit,
 		Offset: offset,
 	})
+}
+
+// @Summary Get details of a specific admin
+// @Description Retrieves all of an admins relevant information.
+// @Tags Admins
+// @Produce json
+// @Security Bearer
+// @Param admin_id path int true "Admin ID"
+// @Success 200 {object} types.Admin
+// @Router /admins/{admin_id} [get]
+func (h *Handler) handleGetAdmin(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	adminIDStr := vars["admin_id"]
+
+	adminID, err := strconv.Atoi(adminIDStr)
+	if err != nil {
+		utils.WriteError(w, http.StatusBadRequest, fmt.Errorf("invalid admin ID: %v", adminID))
+		return
+	}
+
+	admin, err := h.store.GetAdminByID(adminID)
+	if err != nil {
+		utils.WriteError(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	if admin == nil {
+		utils.WriteError(w, http.StatusNotFound, fmt.Errorf("admin with id %v does not exist", adminID))
+		return
+	}
+
+	utils.WriteJson(w, http.StatusOK, admin)
 }
 
 // @Summary Logs in an admin.

--- a/web-client/src/api/admins/model.ts
+++ b/web-client/src/api/admins/model.ts
@@ -29,3 +29,9 @@ export const adminLoginResponseSchema = z.object({
   token: z.string(),
 });
 export type AdminLoginResponse = z.infer<typeof adminLoginResponseSchema>;
+
+export const authResponseSchema = z.object({
+  token: z.string(),
+  admin: adminSchema,
+});
+export type AuthResponse = z.infer<typeof authResponseSchema>;

--- a/web-client/src/api/admins/queries.ts
+++ b/web-client/src/api/admins/queries.ts
@@ -9,8 +9,8 @@ import toast from "react-hot-toast";
 
 import {
   AdminLoginRequest,
-  AdminLoginResponse,
   AdminsPaginatedResponse,
+  AuthResponse,
 } from "./model";
 import { HttpAdminService } from "./service";
 
@@ -23,7 +23,6 @@ export function useGetAdminsOptions(limit = 50, offset = 0, enabled = true) {
     enabled,
   });
 }
-
 export function useGetAdmins(
   limit?: number,
   offset?: number,
@@ -32,15 +31,26 @@ export function useGetAdmins(
   return useQuery(useGetAdminsOptions(limit, offset, enabled));
 }
 
+export function useGetAdminByIdOptions(adminId: number, enabled = true) {
+  return queryOptions({
+    queryKey: ["admins", { adminId }],
+    queryFn: () => adminService.getAdminById(adminId),
+    enabled,
+  });
+}
+export function useGetAdminById(adminId: number, enabled?: boolean) {
+  return useQuery(useGetAdminByIdOptions(adminId, enabled));
+}
+
 export function useLoginAdminMutation(): UseMutationResult<
-  AdminLoginResponse,
+  AuthResponse,
   Error,
   AdminLoginRequest
 > {
   return useMutation({
     mutationFn: (params) => adminService.login(params),
-    onSuccess: () => {
-      toast.success("Welcome back!");
+    onSuccess: (data) => {
+      toast.success(`Welcome back, ${data.admin.firstname}!`);
     },
     onError: (err) => {
       toast.error(`Failed to login: ${err.message}`);

--- a/web-client/src/api/admins/service.ts
+++ b/web-client/src/api/admins/service.ts
@@ -44,8 +44,11 @@ export class HttpAdminService implements AdminService {
     // For `getAdminById` to work, `token` must be in local storage ahead of time.
     localStorage.setItem(LOCAL_STORAGE_AUTH_TOKEN_KEY, token);
 
-    const { userId } = decodeJwtToken(token);
-    const admin = await this.getAdminById(userId);
+    const decodedToken = decodeJwtToken(token);
+    if (!decodedToken) {
+      throw new Error(`Unable to decode auth token.`);
+    }
+    const admin = await this.getAdminById(decodedToken.userId);
 
     return { token, admin };
   }

--- a/web-client/src/api/admins/service.ts
+++ b/web-client/src/api/admins/service.ts
@@ -1,4 +1,5 @@
 import axiosInstance from "@/shared/axios";
+import { LOCAL_STORAGE_AUTH_TOKEN_KEY } from "@/shared/constants";
 import { decodeJwtToken } from "@/shared/utils/jwt";
 
 import {
@@ -40,6 +41,8 @@ export class HttpAdminService implements AdminService {
   async login(payload: AdminLoginRequest): Promise<AuthResponse> {
     const { data } = await axiosInstance.post("/api/v1/admins/login", payload);
     const { token } = adminLoginResponseSchema.parse(data);
+    // For `getAdminById` to work, `token` must be in local storage ahead of time.
+    localStorage.setItem(LOCAL_STORAGE_AUTH_TOKEN_KEY, token);
 
     const { userId } = decodeJwtToken(token);
     const admin = await this.getAdminById(userId);

--- a/web-client/src/components/AuthProtectedRoutes.tsx
+++ b/web-client/src/components/AuthProtectedRoutes.tsx
@@ -1,6 +1,8 @@
 import { useAuth } from "@/context/AuthContext";
 import { Navigate, Outlet } from "react-router-dom";
 
+import { LoadingSpinner } from "./LoadingSpinner";
+
 interface AuthRouteProps {
   redirectPath?: string;
 }
@@ -8,7 +10,16 @@ interface AuthRouteProps {
 export default function AuthProtectedRoutes({
   redirectPath = "/admin/login",
 }: AuthRouteProps) {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, isFetchingToken } = useAuth();
+
+  if (isFetchingToken) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center text-primary">
+        <LoadingSpinner size={48} />
+        <p className="ml-3 mt-2 text-lg text-gray-700">Authorizing...</p>
+      </div>
+    );
+  }
 
   if (!isAuthenticated) {
     return <Navigate to={redirectPath} replace />;

--- a/web-client/src/components/LoadingSpinner.tsx
+++ b/web-client/src/components/LoadingSpinner.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/shared/utils/css";
+
+interface LoadingSpinnerProps extends React.SVGProps<SVGSVGElement> {
+  size?: 24 | 32 | 48 | 64 | 96;
+  className?: string;
+}
+
+export function LoadingSpinner({
+  size = 32,
+  className,
+  ...props
+}: LoadingSpinnerProps) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      {...props}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-label="Loading..."
+      className={cn("animate-spin", className)}
+    >
+      <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+    </svg>
+  );
+}

--- a/web-client/src/components/NotFound.tsx
+++ b/web-client/src/components/NotFound.tsx
@@ -1,9 +1,16 @@
+import { useAuth } from "@/context/AuthContext";
 import { Home, Undo2 } from "lucide-react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { Button } from "./ui/button";
 
 export default function NotFound() {
+  const navigate = useNavigate();
+  const { isAuthenticated } = useAuth();
+
+  const isAdminPath = window.location.pathname.startsWith("/admin");
+  const homePath = isAuthenticated && isAdminPath ? "/admin/home" : "/home";
+
   return (
     <div className="flex min-h-screen items-center justify-center bg-background px-4">
       <div className="w-full max-w-md space-y-8 text-center">
@@ -36,10 +43,8 @@ export default function NotFound() {
               <Undo2 className="mr-2 h-4 w-4" /> Back
             </Button>
 
-            <Button asChild>
-              <Link to="/">
-                <Home className="mr-2 h-4 w-4" /> Home
-              </Link>
+            <Button onClick={() => navigate(homePath)}>
+              <Home className="mr-2 h-4 w-4" /> Home
             </Button>
           </div>
         </div>

--- a/web-client/src/context/AuthContext.tsx
+++ b/web-client/src/context/AuthContext.tsx
@@ -1,6 +1,7 @@
-import { useLoginAdminMutation } from "@/api/admins/queries";
+import { Admin } from "@/api/admins/model";
+import { useGetAdminById, useLoginAdminMutation } from "@/api/admins/queries";
 import { LOCAL_STORAGE_AUTH_TOKEN_KEY } from "@/shared/constants";
-import { isJwtTokenExpired } from "@/shared/utils/jwt";
+import { decodeJwtToken, isJwtTokenExpired } from "@/shared/utils/jwt";
 import {
   ReactNode,
   createContext,
@@ -14,6 +15,8 @@ import { useNavigate } from "react-router-dom";
 interface AuthContextType {
   /** JWT token for the logged in admin. */
   token: string | null;
+  /** Details of the currently logged in admin. */
+  admin: Admin | null;
   /** True if the JWT token is valid, and is not expired. */
   isAuthenticated: boolean;
   /** Logs in an admin. */
@@ -21,7 +24,7 @@ interface AuthContextType {
   /** Logs out the currently signed in admin. */
   logout: () => void;
   /** True if the admin is currently logging in. */
-  isLoading: boolean;
+  isLoggingIn: boolean;
 }
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
@@ -34,8 +37,14 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const loginMutation = useLoginAdminMutation();
 
   const [token, setToken] = useState<string | null>(null);
+  const [admin, setAdmin] = useState<Admin | null>(null);
   const isAuthenticated = Boolean(token && !isJwtTokenExpired(token));
-  const isLoading = loginMutation.isPending;
+  const isLoggingIn = loginMutation.isPending;
+
+  const adminQuery = useGetAdminById(
+    token ? decodeJwtToken(token).userId : 0,
+    Boolean(token && !admin),
+  );
 
   useEffect(() => {
     const storedToken = localStorage.getItem(LOCAL_STORAGE_AUTH_TOKEN_KEY);
@@ -49,15 +58,33 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     }
   }, []);
 
+  useEffect(() => {
+    if (adminQuery.data) {
+      setAdmin(adminQuery.data);
+    }
+  }, [adminQuery.data?.id]);
+
+  useEffect(() => {
+    if (adminQuery.isError) {
+      toast.error("Unable to fetch admin metadata.");
+    }
+  }, [adminQuery.isError]);
+
   const login = async (username: string, password: string) => {
-    const { token } = await loginMutation.mutateAsync({ username, password });
+    const { token, admin } = await loginMutation.mutateAsync({
+      username,
+      password,
+    });
+
     setToken(token);
     localStorage.setItem(LOCAL_STORAGE_AUTH_TOKEN_KEY, token);
+    setAdmin(admin);
   };
 
   const logout = () => {
     setToken(null);
     localStorage.removeItem(LOCAL_STORAGE_AUTH_TOKEN_KEY);
+    setAdmin(null);
 
     navigate("/admin/login");
     toast.success("Logged out.");
@@ -65,7 +92,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
   return (
     <AuthContext.Provider
-      value={{ token, isAuthenticated, login, logout, isLoading }}
+      value={{ token, admin, isAuthenticated, login, logout, isLoggingIn }}
     >
       {children}
     </AuthContext.Provider>

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -27,16 +27,18 @@ createRoot(document.getElementById("root")!).render(
             <Route path="/" element={<RootLayout />}>
               <Route index element={<Navigate to="/home" replace />} />
               <Route path="home" element={<HomePage />} />
+
+              <Route path="*" element={<NotFound />} />
             </Route>
+            <Route path="/admin/login" element={<AdminLoginPage />} />
 
             {/* ----- Admin dashboard ----- */}
-            <Route path="/admin" element={<AdminLayout />}>
-              <Route index element={<Navigate to="/admin/home" replace />} />
-              <Route path="login" element={<AdminLoginPage />} />
-
-              {/* --- Auth protected routes --- */}
-              <Route element={<AuthProtectedRoutes />}>
+            <Route element={<AuthProtectedRoutes />}>
+              <Route path="/admin" element={<AdminLayout />}>
+                <Route index element={<Navigate to="/admin/home" replace />} />
                 <Route path="home" element={<AdminHomePage />} />
+
+                <Route path="*" element={<NotFound />} />
               </Route>
             </Route>
 

--- a/web-client/src/pages/admin/AdminLoginPage.tsx
+++ b/web-client/src/pages/admin/AdminLoginPage.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from "react-router-dom";
 
 export default function AdminLoginPage() {
   const navigate = useNavigate();
-  const { login, isLoading, isAuthenticated } = useAuth();
+  const { login, isLoggingIn, isAuthenticated } = useAuth();
 
   const [username, setUsername] = useState<string>("");
   const [password, setPassword] = useState<string>("");
@@ -54,9 +54,9 @@ export default function AdminLoginPage() {
 
           login(username, password);
         }}
-        disabled={isLoading || isAuthenticated}
+        disabled={isLoggingIn || isAuthenticated}
       >
-        {isLoading ? "Logging in..." : "Login"}
+        {isLoggingIn ? "Logging in..." : "Login"}
       </Button>
     </>
   );

--- a/web-client/src/shared/utils/jwt.ts
+++ b/web-client/src/shared/utils/jwt.ts
@@ -2,8 +2,8 @@ import { jwtDecode } from "jwt-decode";
 
 /** The decoded public claims from the signed auth, JWT token. */
 export interface DecodedAuthToken {
-  /** ID of the admin that owns this token. */
-  adminId: number;
+  /** ID of the user that owns this token. */
+  userId: number;
   /** Expiration time in seconds since Unix epoch. */
   expiredAt: number;
 }

--- a/web-client/src/shared/utils/jwt.ts
+++ b/web-client/src/shared/utils/jwt.ts
@@ -11,20 +11,30 @@ export interface DecodedAuthToken {
 /**
  * Decodes a valid JWT token's public claims.
  * @param token string token representation
- * @returns a `DecodedAuthToken` with all claims.
+ * @returns a `DecodedAuthToken` with all claims OR if the token is invalid, it will return `null`.
  */
-export function decodeJwtToken(token: string): DecodedAuthToken {
-  const decodedToken: DecodedAuthToken = jwtDecode(token);
+export function decodeJwtToken(token: string): DecodedAuthToken | null {
+  let decodedToken: DecodedAuthToken | null = null;
+  try {
+    decodedToken = jwtDecode(token);
+  } catch (e: unknown) {
+    console.error(`Unable to decode JWT token "${token}" -> ${e}`);
+  }
+
   return decodedToken;
 }
 
 /**
  * Determines if a JWT token has expired.
  * @param token string token representation
- * @returns true if token has not expired, false otherwise
+ * @returns true if token has not expired (or it was unable to be decoded), false otherwise
  */
 export function isJwtTokenExpired(token: string): boolean {
   const decodedToken = decodeJwtToken(token);
+  if (!decodedToken) {
+    return true;
+  }
+
   const currentTimestampInSeconds = Math.floor(Date.now() / 1000);
   return decodedToken.expiredAt < currentTimestampInSeconds;
 }


### PR DESCRIPTION
## Description

When an admin logs in, they can now see "Welcome back, {firstname}!" within the toast bar. So, to make it happen, I updated the backend to have an endpoint to fetch an individual admins data. Then, I updated the UI to fetch the metadata upon successful login.

## Changes

- Adds the /GET /admins/:admin_id endpoint
- Updates the UI to fetch admin metadata upon login
- Adds loading spinner component
- Fixes some issues related to 404 pages when logged in vs. not logged in

## Screenshots/demo

![Kapture 2024-10-11 at 16 41 04](https://github.com/user-attachments/assets/acc897a3-aa8e-49c6-8b02-0980ccb9806b)

## Related issues

Closes #65 
