### PR TITLE
feat: adds order confirmation ui

### DIFF
--- a/web-client/src/api/admins/queries.ts
+++ b/web-client/src/api/admins/queries.ts
@@ -8,6 +8,7 @@ import { UseMutationResult } from "node_modules/@tanstack/react-query/build/lega
 import toast from "react-hot-toast";
 
 import {
+  Admin,
   AdminLoginRequest,
   AdminsPaginatedResponse,
   AuthResponse,
@@ -27,7 +28,7 @@ export function useGetAdmins(
   limit?: number,
   offset?: number,
   enabled?: boolean,
-): UseQueryResult<AdminsPaginatedResponse, Error> {
+): UseQueryResult<AdminsPaginatedResponse> {
   return useQuery(useGetAdminsOptions(limit, offset, enabled));
 }
 
@@ -38,7 +39,10 @@ export function useGetAdminByIdOptions(adminId: number, enabled = true) {
     enabled,
   });
 }
-export function useGetAdminById(adminId: number, enabled?: boolean) {
+export function useGetAdminById(
+  adminId: number,
+  enabled?: boolean,
+): UseQueryResult<Admin> {
   return useQuery(useGetAdminByIdOptions(adminId, enabled));
 }
 

--- a/web-client/src/api/cart/model.ts
+++ b/web-client/src/api/cart/model.ts
@@ -1,93 +1,17 @@
 import { z } from "zod";
 
-export const addressSchema = z.object({
-  street: z.string(),
-  aptUnit: z.string(),
-  //   city: z.string(),
-  state: z.enum([
-    "AL",
-    "AK",
-    "AZ",
-    "AR",
-    "CA",
-    "CO",
-    "CT",
-    "DE",
-    "FL",
-    "GA",
-    "HI",
-    "ID",
-    "IL",
-    "IN",
-    "IA",
-    "KS",
-    "KY",
-    "LA",
-    "ME",
-    "MD",
-    "MA",
-    "MI",
-    "MN",
-    "MS",
-    "MO",
-    "MT",
-    "NE",
-    "NV",
-    "NH",
-    "NJ",
-    "NM",
-    "NY",
-    "NC",
-    "ND",
-    "OH",
-    "OK",
-    "OR",
-    "PA",
-    "RI",
-    "SC",
-    "SD",
-    "TN",
-    "TX",
-    "UT",
-    "VT",
-    "VA",
-    "WA",
-    "WV",
-    "WI",
-    "WY",
-  ]),
-  zipcode: z.string(),
-});
-export type Address = z.infer<typeof addressSchema>;
-
-export const sockSizeEnumSchema = z.enum(["S", "M", "LG", "XL"]);
-export type SockSize = z.infer<typeof sockSizeEnumSchema>;
-
-export const orderItemSchema = z.object({
-  name: z.string(),
-  price: z.number(),
-  quantity: z.number(),
-  size: sockSizeEnumSchema,
-  sockVariantId: z.number(),
-});
-export const orderItemListSchema = z.array(orderItemSchema);
-export type OrderItem = z.infer<typeof orderItemSchema>;
-
-export const orderStatusEnumSchema = z.enum([
-  "pending",
-  "received",
-  "shipped",
-  "delivered",
-  "canceled",
-  "returned",
-]);
-export type OrderStatus = z.infer<typeof orderStatusEnumSchema>;
+import {
+  orderAddressSchema,
+  orderItemListSchema,
+  orderStatusEnumSchema,
+  sockSizeEnumSchema,
+} from "../orders/model";
 
 export const orderConfirmationSchema = z.object({
   invoiceNumber: z.string(),
   total: z.number(),
   status: orderStatusEnumSchema,
-  address: addressSchema,
+  address: orderAddressSchema,
   items: orderItemListSchema,
   createdAt: z.string(),
 });

--- a/web-client/src/api/cart/model.ts
+++ b/web-client/src/api/cart/model.ts
@@ -70,10 +70,8 @@ export const orderItemSchema = z.object({
   size: sockSizeEnumSchema,
   sockVariantId: z.number(),
 });
-export type OrderItem = z.infer<typeof orderItemSchema>;
-
 export const orderItemListSchema = z.array(orderItemSchema);
-export type OrderItemList = z.infer<typeof orderItemListSchema>;
+export type OrderItem = z.infer<typeof orderItemSchema>;
 
 export const orderStatusEnumSchema = z.enum([
   "pending",
@@ -94,3 +92,14 @@ export const orderConfirmationSchema = z.object({
   createdAt: z.string(),
 });
 export type OrderConfirmation = z.infer<typeof orderConfirmationSchema>;
+
+export const cartItemSchema = z.object({
+  sockVariantId: z.number(),
+  name: z.string(),
+  quantity: z.number(),
+  price: z.number(),
+  size: sockSizeEnumSchema,
+  imageUrl: z.string(),
+});
+export const cartItemListSchema = z.array(cartItemSchema);
+export type CartItem = z.infer<typeof cartItemSchema>;

--- a/web-client/src/api/cart/model.ts
+++ b/web-client/src/api/cart/model.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+export const addressSchema = z.object({
+  street: z.string(),
+  aptUnit: z.string(),
+  //   city: z.string(),
+  state: z.enum([
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+  ]),
+  zipcode: z.string(),
+});
+export type Address = z.infer<typeof addressSchema>;
+
+export const sockSizeEnumSchema = z.enum(["S", "M", "LG", "XL"]);
+export type SockSize = z.infer<typeof sockSizeEnumSchema>;
+
+export const orderItemSchema = z.object({
+  name: z.string(),
+  price: z.number(),
+  quantity: z.number(),
+  size: sockSizeEnumSchema,
+  sockVariantId: z.number(),
+});
+export type OrderItem = z.infer<typeof orderItemSchema>;
+
+export const orderItemListSchema = z.array(orderItemSchema);
+export type OrderItemList = z.infer<typeof orderItemListSchema>;
+
+export const orderStatusEnumSchema = z.enum([
+  "pending",
+  "received",
+  "shipped",
+  "delivered",
+  "canceled",
+  "returned",
+]);
+export type OrderStatus = z.infer<typeof orderStatusEnumSchema>;
+
+export const orderConfirmationSchema = z.object({
+  invoiceNumber: z.string(),
+  total: z.number(),
+  status: orderStatusEnumSchema,
+  address: addressSchema,
+  items: orderItemListSchema,
+  createdAt: z.string(),
+});
+export type OrderConfirmation = z.infer<typeof orderConfirmationSchema>;

--- a/web-client/src/api/cart/queries.ts
+++ b/web-client/src/api/cart/queries.ts
@@ -13,6 +13,6 @@ export function useGetStripeOrderConfirmationOptions(sessionId: string) {
 }
 export function useGetStripeOrderConfirmation(
   sessionId: string,
-): UseQueryResult<OrderConfirmation, Error> {
+): UseQueryResult<OrderConfirmation> {
   return useQuery(useGetStripeOrderConfirmationOptions(sessionId));
 }

--- a/web-client/src/api/cart/queries.ts
+++ b/web-client/src/api/cart/queries.ts
@@ -1,0 +1,18 @@
+import { UseQueryResult, queryOptions, useQuery } from "@tanstack/react-query";
+
+import { OrderConfirmation } from "./model";
+import { HttpCartService } from "./service";
+
+const cartService = new HttpCartService();
+
+export function useGetStripeOrderConfirmationOptions(sessionId: string) {
+  return queryOptions({
+    queryKey: ["order-confirmation", { sessionId }],
+    queryFn: () => cartService.getStripeOrderConfirmation(sessionId),
+  });
+}
+export function useGetStripeOrderConfirmation(
+  sessionId: string,
+): UseQueryResult<OrderConfirmation, Error> {
+  return useQuery(useGetStripeOrderConfirmationOptions(sessionId));
+}

--- a/web-client/src/api/cart/queries.ts
+++ b/web-client/src/api/cart/queries.ts
@@ -5,14 +5,15 @@ import { HttpCartService } from "./service";
 
 const cartService = new HttpCartService();
 
-export function useGetStripeOrderConfirmationOptions(sessionId: string) {
+export function useGetStripeOrderConfirmationOptions(sessionId: string | null) {
   return queryOptions({
     queryKey: ["order-confirmation", { sessionId }],
-    queryFn: () => cartService.getStripeOrderConfirmation(sessionId),
+    queryFn: () => cartService.getStripeOrderConfirmation(sessionId!),
+    enabled: Boolean(sessionId),
   });
 }
 export function useGetStripeOrderConfirmation(
-  sessionId: string,
+  sessionId: string | null,
 ): UseQueryResult<OrderConfirmation> {
   return useQuery(useGetStripeOrderConfirmationOptions(sessionId));
 }

--- a/web-client/src/api/cart/service.ts
+++ b/web-client/src/api/cart/service.ts
@@ -1,0 +1,18 @@
+import axiosInstance from "@/shared/axios";
+
+import { OrderConfirmation, orderConfirmationSchema } from "./model";
+
+interface CartService {
+  getStripeOrderConfirmation(sessionId: string): Promise<OrderConfirmation>;
+}
+
+export class HttpCartService implements CartService {
+  async getStripeOrderConfirmation(
+    sessionId: string,
+  ): Promise<OrderConfirmation> {
+    const { data } = await axiosInstance.get(
+      `/api/v1/cart/checkout/stripe-confirmation/${sessionId}`,
+    );
+    return orderConfirmationSchema.parse(data);
+  }
+}

--- a/web-client/src/api/cart/service.ts
+++ b/web-client/src/api/cart/service.ts
@@ -2,7 +2,7 @@ import axiosInstance from "@/shared/axios";
 
 import { OrderConfirmation, orderConfirmationSchema } from "./model";
 
-interface CartService {
+export interface CartService {
   getStripeOrderConfirmation(sessionId: string): Promise<OrderConfirmation>;
 }
 

--- a/web-client/src/api/orders/model.ts
+++ b/web-client/src/api/orders/model.ts
@@ -1,9 +1,104 @@
 import { z } from "zod";
 
+export const orderAddressSchema = z.object({
+  street: z.string(),
+  aptUnit: z.string(),
+  //   city: z.string(),
+  state: z.enum([
+    "AL",
+    "AK",
+    "AZ",
+    "AR",
+    "CA",
+    "CO",
+    "CT",
+    "DE",
+    "FL",
+    "GA",
+    "HI",
+    "ID",
+    "IL",
+    "IN",
+    "IA",
+    "KS",
+    "KY",
+    "LA",
+    "ME",
+    "MD",
+    "MA",
+    "MI",
+    "MN",
+    "MS",
+    "MO",
+    "MT",
+    "NE",
+    "NV",
+    "NH",
+    "NJ",
+    "NM",
+    "NY",
+    "NC",
+    "ND",
+    "OH",
+    "OK",
+    "OR",
+    "PA",
+    "RI",
+    "SC",
+    "SD",
+    "TN",
+    "TX",
+    "UT",
+    "VT",
+    "VA",
+    "WA",
+    "WV",
+    "WI",
+    "WY",
+  ]),
+  zipcode: z.string(),
+});
+export type OrderAddress = z.infer<typeof orderAddressSchema>;
+
+export const orderContactSchema = z.object({
+  firstname: z.string(),
+  lastname: z.string(),
+  email: z.string().email(),
+  phone: z.string(),
+});
+export type OrderContact = z.infer<typeof orderContactSchema>;
+
+export const sockSizeEnumSchema = z.enum(["S", "M", "LG", "XL"]);
+export type SockSize = z.infer<typeof sockSizeEnumSchema>;
+
+export const orderItemSchema = z.object({
+  name: z.string(),
+  price: z.number(),
+  quantity: z.number(),
+  size: sockSizeEnumSchema,
+  sockVariantId: z.number(),
+});
+export const orderItemListSchema = z.array(orderItemSchema);
+export type OrderItem = z.infer<typeof orderItemSchema>;
+
+export const orderStatusEnumSchema = z.enum([
+  "pending",
+  "received",
+  "shipped",
+  "delivered",
+  "canceled",
+  "returned",
+]);
+export type OrderStatus = z.infer<typeof orderStatusEnumSchema>;
+
 export const orderSchema = z.object({
+  orderId: z.number().optional(),
   invoiceNumber: z.string(),
   total: z.number(),
-  status: z.string(),
+  status: orderStatusEnumSchema,
+  address: orderAddressSchema,
+  contact: orderContactSchema,
+  items: orderItemListSchema,
+  createdAt: z.string().optional(),
 });
-
 export type Order = z.infer<typeof orderSchema>;

--- a/web-client/src/api/orders/queries.ts
+++ b/web-client/src/api/orders/queries.ts
@@ -1,25 +1,20 @@
-import { UseQueryResult, useQuery } from "@tanstack/react-query";
+import { UseQueryResult, queryOptions, useQuery } from "@tanstack/react-query";
+
 import { Order } from "./model";
 import { HttpOrderService } from "./service";
-import toast from "react-hot-toast";
 
 const orderService = new HttpOrderService();
 
 export function useGetOrderByIdOptions(orderId: number, enabled = true) {
-  return {
+  return queryOptions({
     queryKey: ["order", { orderId }],
     queryFn: () => orderService.getOrderById(orderId),
     enabled,
-    onError: (error: Error) => {
-      toast.error(`Failed to fetch order: ${error.message}`);
-    },
-  };
+  });
 }
-
 export function useGetOrderById(
   orderId: number,
-  enabled = true
-): UseQueryResult<Order, Error> {
+  enabled = true,
+): UseQueryResult<Order> {
   return useQuery(useGetOrderByIdOptions(orderId, enabled));
 }
-

--- a/web-client/src/api/orders/service.ts
+++ b/web-client/src/api/orders/service.ts
@@ -2,7 +2,11 @@ import axiosInstance from "@/shared/axios";
 
 import { Order, orderSchema } from "./model";
 
-export class HttpOrderService {
+export interface OrderService {
+  getOrderById(orderId: number): Promise<Order>;
+}
+
+export class HttpOrderService implements OrderService {
   async getOrderById(orderId: number): Promise<Order> {
     const { data } = await axiosInstance.get(`/api/v1/orders/${orderId}`);
     return orderSchema.parse(data);

--- a/web-client/src/api/orders/service.ts
+++ b/web-client/src/api/orders/service.ts
@@ -1,5 +1,6 @@
 import axiosInstance from "@/shared/axios";
-import { orderSchema, Order } from "./model";
+
+import { Order, orderSchema } from "./model";
 
 export class HttpOrderService {
   async getOrderById(orderId: number): Promise<Order> {
@@ -7,4 +8,3 @@ export class HttpOrderService {
     return orderSchema.parse(data);
   }
 }
-

--- a/web-client/src/components/CartDemo.tsx
+++ b/web-client/src/components/CartDemo.tsx
@@ -1,0 +1,143 @@
+import { CartItem } from "@/api/cart/model";
+import { Button } from "@/components/ui/button";
+import { useCart } from "@/context/CartContext";
+
+const item1: CartItem = {
+  sockVariantId: 1,
+  name: "Classic Socks",
+  quantity: 1,
+  price: 19.0,
+  size: "LG",
+  imageUrl: "some url",
+};
+
+const item2: CartItem = {
+  sockVariantId: 2,
+  name: "Retro Socks",
+  quantity: 2,
+  price: 30.0,
+  size: "S",
+  imageUrl: "some url",
+};
+
+const invalidItem: CartItem = {
+  sockVariantId: 2,
+  name: "Out of Phase Rockers",
+  quantity: -20,
+  price: 30.0,
+  size: "XL",
+  imageUrl: "some url",
+};
+
+export default function CartDemo() {
+  const { addItem, items, removeItem, empty, updateItem, isLoading } =
+    useCart();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="space-x-2">
+        <Button
+          onClick={() => {
+            addItem(item1);
+          }}
+        >
+          +1 Add (Classic socks)
+        </Button>
+
+        <Button
+          onClick={() => {
+            addItem(item2);
+          }}
+        >
+          +2 Add (Retro socks)
+        </Button>
+
+        <Button
+          onClick={() => {
+            addItem(invalidItem);
+          }}
+        >
+          Add Invalid Item
+        </Button>
+      </div>
+
+      <div className="space-x-2">
+        <Button
+          variant="destructive"
+          onClick={() => {
+            removeItem(item1);
+          }}
+        >
+          Remove (Classic socks)
+        </Button>
+
+        <Button
+          variant="destructive"
+          onClick={() => {
+            removeItem(item2);
+          }}
+        >
+          Remove (Retro socks)
+        </Button>
+      </div>
+
+      <div className="flex flex-wrap gap-4">
+        <Button onClick={() => updateItem(1, { ...item1, quantity: 10 })}>
+          Set "Classic socks" Quantity to 10
+        </Button>
+        <Button onClick={() => updateItem(2, { ...item2, quantity: 20 })}>
+          Set "Retro socks" Quantity to 20
+        </Button>
+
+        <Button onClick={() => updateItem(1, { ...item1, quantity: 0 })}>
+          Set "Classic socks" Quantity to 0
+        </Button>
+        <Button onClick={() => updateItem(2, { ...item2, quantity: -20 })}>
+          Set "Retro socks" Quantity to -20
+        </Button>
+      </div>
+
+      <Button
+        variant="outline"
+        onClick={() => {
+          empty();
+        }}
+      >
+        Clear
+      </Button>
+
+      <div className="flex flex-col gap-6">
+        {isLoading && <p>Loading cart...</p>}
+
+        {items.length > 0
+          ? items.map((item) => (
+              <div key={item.sockVariantId}>
+                [Q: {item.quantity}] {item.name} ({item.size}) - ${item.price}{" "}
+                <Button
+                  variant="destructive"
+                  onClick={() =>
+                    updateItem(item.sockVariantId, {
+                      ...item,
+                      quantity: item.quantity - 1,
+                    })
+                  }
+                >
+                  -1 Decrement
+                </Button>{" "}
+                <Button
+                  onClick={() =>
+                    updateItem(item.sockVariantId, {
+                      ...item,
+                      quantity: item.quantity + 1,
+                    })
+                  }
+                >
+                  +1 Increment
+                </Button>
+              </div>
+            ))
+          : !isLoading && <p>Cart is empty.</p>}
+      </div>
+    </div>
+  );
+}

--- a/web-client/src/components/GenericError.tsx
+++ b/web-client/src/components/GenericError.tsx
@@ -19,7 +19,7 @@ import { Link } from "react-router-dom";
 
 import LoadingSpinner from "./LoadingSpinner";
 
-const MAX_STACK_TRACE_CHAR_LENGTH = 400;
+const MAX_STACK_TRACE_CHAR_LENGTH = 325;
 
 interface GenericErrorProps {
   title?: string;
@@ -53,7 +53,7 @@ export default function GenericError({
   };
 
   return (
-    <div className="flex h-full items-center justify-center bg-background p-4">
+    <div className="flex h-full items-center justify-center bg-background">
       <Card className="w-full max-w-3xl">
         <CardHeader className="text-center">
           <div className="mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full bg-destructive/10">

--- a/web-client/src/components/GenericError.tsx
+++ b/web-client/src/components/GenericError.tsx
@@ -53,7 +53,7 @@ export default function GenericError({
   };
 
   return (
-    <div className="flex h-full items-center justify-center bg-background">
+    <div className="flex h-full items-center justify-center bg-background px-4">
       <Card className="w-full max-w-3xl">
         <CardHeader className="text-center">
           <div className="mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full bg-destructive/10">

--- a/web-client/src/components/GenericError.tsx
+++ b/web-client/src/components/GenericError.tsx
@@ -1,0 +1,99 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useAuth } from "@/context/AuthContext";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  MessageCircle,
+  RefreshCcw,
+} from "lucide-react";
+import { ReactNode, useState } from "react";
+import { Link } from "react-router-dom";
+
+import LoadingSpinner from "./LoadingSpinner";
+
+interface ErrorProps {
+  title?: string;
+  message?: string;
+  customContent?: ReactNode;
+  showRefresh?: boolean;
+  showContactSupport?: boolean;
+  showReturnHome?: boolean;
+}
+
+export default function GenericError({
+  title = "An error occurred",
+  message = "We're sorry, but something went wrong. Please try again or contact support if the issue persists.",
+  customContent,
+  showRefresh = true,
+  showContactSupport = true,
+  showReturnHome = true,
+}: ErrorProps) {
+  const { isAuthenticated } = useAuth();
+  const isAdminPath = window.location.pathname.startsWith("/admin");
+  const homePath = isAuthenticated && isAdminPath ? "/admin/home" : "/home";
+
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleRefresh = () => {
+    setIsRefreshing(true);
+    window.location.reload();
+  };
+
+  return (
+    <div className="flex h-full items-center justify-center bg-background p-4">
+      <Card className="w-full max-w-xl">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full bg-destructive/10">
+            <AlertTriangle className="h-12 w-12 text-destructive" />
+          </div>
+          <CardTitle className="text-2xl font-bold">{title}</CardTitle>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          <p className="text-center text-muted-foreground">{message}</p>
+          {customContent && (
+            <div className="rounded-lg bg-muted p-4">{customContent}</div>
+          )}
+        </CardContent>
+
+        <CardFooter className="flex flex-col space-y-2">
+          {showRefresh && (
+            <Button
+              className="w-full"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+            >
+              {isRefreshing ? (
+                <LoadingSpinner size={16} className="mr-2" />
+              ) : (
+                <RefreshCcw className="mr-2 h-4 w-4" />
+              )}
+              {isRefreshing ? "Refreshing..." : "Refresh"}
+            </Button>
+          )}
+          {showContactSupport && (
+            <Button variant="outline" className="w-full" asChild>
+              <Link to="/support">
+                <MessageCircle className="mr-2 h-4 w-4" /> Contact support
+              </Link>
+            </Button>
+          )}
+          {showReturnHome && (
+            <Button variant="ghost" className="w-full" asChild>
+              <Link to={homePath}>
+                <ArrowLeft className="mr-2 h-4 w-4" /> Return to home
+              </Link>
+            </Button>
+          )}
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/web-client/src/components/GenericError.tsx
+++ b/web-client/src/components/GenericError.tsx
@@ -45,7 +45,7 @@ export default function GenericError({
   const homePath = isAuthenticated && isAdminPath ? "/admin/home" : "/home";
 
   const [isRefreshing, setIsRefreshing] = useState(false);
-  const [showFullStack, setShowFullStack] = useState(false);
+  const [showFullStackTrace, setShowFullStackTrace] = useState(false);
 
   const handleRefresh = () => {
     setIsRefreshing(true);
@@ -70,20 +70,24 @@ export default function GenericError({
 
           {stackTrace && (
             <div className="overflow-x-auto rounded-lg bg-muted p-4">
+              <p className="text-xs text-muted-foreground">Stack trace</p>
               <code className="whitespace-pre-wrap font-mono text-sm">
-                {showFullStack
+                {showFullStackTrace
                   ? stackTrace
                   : truncate(stackTrace, MAX_STACK_TRACE_CHAR_LENGTH)}
               </code>
               <br />
-              <Button
-                variant="ghost"
-                size="sm"
-                className="mt-2"
-                onClick={() => setShowFullStack(!showFullStack)}
-              >
-                {showFullStack ? "Show less" : "Show more"}
-              </Button>
+
+              {stackTrace?.length > MAX_STACK_TRACE_CHAR_LENGTH && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-2"
+                  onClick={() => setShowFullStackTrace(!showFullStackTrace)}
+                >
+                  {showFullStackTrace ? "Show less" : "Show more"}
+                </Button>
+              )}
             </div>
           )}
         </CardContent>
@@ -105,7 +109,11 @@ export default function GenericError({
           )}
 
           {showContactSupport && (
-            <Button variant="outline" className="w-full" asChild>
+            <Button
+              variant={showRefresh ? "outline" : "default"}
+              className="w-full"
+              asChild
+            >
               <Link to="/support">
                 <MessageCircle className="mr-2 h-4 w-4" /> Contact support
               </Link>

--- a/web-client/src/components/GenericError.tsx
+++ b/web-client/src/components/GenericError.tsx
@@ -7,6 +7,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useAuth } from "@/context/AuthContext";
+import { truncate } from "@/shared/utils/strings";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -18,10 +19,13 @@ import { Link } from "react-router-dom";
 
 import LoadingSpinner from "./LoadingSpinner";
 
-interface ErrorProps {
+const MAX_STACK_TRACE_CHAR_LENGTH = 400;
+
+interface GenericErrorProps {
   title?: string;
   message?: string;
   customContent?: ReactNode;
+  stackTrace?: string;
   showRefresh?: boolean;
   showContactSupport?: boolean;
   showReturnHome?: boolean;
@@ -31,15 +35,17 @@ export default function GenericError({
   title = "An error occurred",
   message = "We're sorry, but something went wrong. Please try again or contact support if the issue persists.",
   customContent,
+  stackTrace = "",
   showRefresh = true,
   showContactSupport = true,
   showReturnHome = true,
-}: ErrorProps) {
+}: GenericErrorProps) {
   const { isAuthenticated } = useAuth();
   const isAdminPath = window.location.pathname.startsWith("/admin");
   const homePath = isAuthenticated && isAdminPath ? "/admin/home" : "/home";
 
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [showFullStack, setShowFullStack] = useState(false);
 
   const handleRefresh = () => {
     setIsRefreshing(true);
@@ -48,18 +54,37 @@ export default function GenericError({
 
   return (
     <div className="flex h-full items-center justify-center bg-background p-4">
-      <Card className="w-full max-w-xl">
+      <Card className="w-full max-w-3xl">
         <CardHeader className="text-center">
           <div className="mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full bg-destructive/10">
             <AlertTriangle className="h-12 w-12 text-destructive" />
           </div>
           <CardTitle className="text-2xl font-bold">{title}</CardTitle>
+          <p className="text-center text-muted-foreground">{message}</p>
         </CardHeader>
 
         <CardContent className="space-y-4">
-          <p className="text-center text-muted-foreground">{message}</p>
           {customContent && (
             <div className="rounded-lg bg-muted p-4">{customContent}</div>
+          )}
+
+          {stackTrace && (
+            <div className="overflow-x-auto rounded-lg bg-muted p-4">
+              <code className="whitespace-pre-wrap font-mono text-sm">
+                {showFullStack
+                  ? stackTrace
+                  : truncate(stackTrace, MAX_STACK_TRACE_CHAR_LENGTH)}
+              </code>
+              <br />
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-2"
+                onClick={() => setShowFullStack(!showFullStack)}
+              >
+                {showFullStack ? "Show less" : "Show more"}
+              </Button>
+            </div>
           )}
         </CardContent>
 
@@ -78,6 +103,7 @@ export default function GenericError({
               {isRefreshing ? "Refreshing..." : "Refresh"}
             </Button>
           )}
+
           {showContactSupport && (
             <Button variant="outline" className="w-full" asChild>
               <Link to="/support">
@@ -85,6 +111,7 @@ export default function GenericError({
               </Link>
             </Button>
           )}
+
           {showReturnHome && (
             <Button variant="ghost" className="w-full" asChild>
               <Link to={homePath}>

--- a/web-client/src/components/dev/CartDemo.tsx
+++ b/web-client/src/components/dev/CartDemo.tsx
@@ -103,7 +103,7 @@ export default function CartDemo() {
           empty();
         }}
       >
-        Clear
+        Empty
       </Button>
 
       <div className="flex flex-col gap-6">

--- a/web-client/src/context/CartContext.tsx
+++ b/web-client/src/context/CartContext.tsx
@@ -3,6 +3,7 @@ import { LOCAL_STORAGE_CART_ITEMS_KEY } from "@/shared/constants";
 import {
   ReactNode,
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useState,
@@ -114,13 +115,13 @@ export function CartProvider({ children }: CartProviderProps) {
     localStorage.removeItem(LOCAL_STORAGE_CART_ITEMS_KEY);
   };
 
-  const saveToStorage = () => {
+  const saveToStorage = useCallback(() => {
     if (items.length > 0) {
       localStorage.setItem(LOCAL_STORAGE_CART_ITEMS_KEY, JSON.stringify(items));
     }
-  };
+  }, [items]);
 
-  const loadFromStorage = () => {
+  const loadFromStorage = useCallback(() => {
     const stringifiedStoredItems = localStorage.getItem(
       LOCAL_STORAGE_CART_ITEMS_KEY,
     );
@@ -137,16 +138,16 @@ export function CartProvider({ children }: CartProviderProps) {
         empty();
       }
     }
-  };
+  }, []);
 
   useEffect(() => {
     loadFromStorage();
     setIsLoading(false);
-  }, []);
+  }, [loadFromStorage]);
 
   useEffect(() => {
     saveToStorage();
-  }, [JSON.stringify(items)]);
+  }, [items, saveToStorage]);
 
   return (
     <CartContext.Provider

--- a/web-client/src/context/CartContext.tsx
+++ b/web-client/src/context/CartContext.tsx
@@ -1,0 +1,173 @@
+import { CartItem, cartItemListSchema } from "@/api/cart/model";
+import { LOCAL_STORAGE_CART_ITEMS_KEY } from "@/shared/constants";
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import toast from "react-hot-toast";
+
+interface CartContextType {
+  /** Items currently in the cart. */
+  items: CartItem[];
+  /** Method to add an item to the cart, or increase its quantity if already present */
+  addItem: (newItem: CartItem) => void;
+  /** Method to remove an item completely from the cart based on its ID */
+  removeItem: (item: CartItem) => void;
+  /** Method to update the details of a specific item in the cart */
+  updateItem: (sockVariantId: number, updatedItem: CartItem) => void;
+  /** Method to empty all items from the cart (e.g., after checkout) */
+  empty: () => void;
+  /** True when the cart is being retrieved from local storage, false otherwise. */
+  isLoading: boolean;
+}
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+interface CartProviderProps {
+  children?: ReactNode;
+}
+
+export function CartProvider({ children }: CartProviderProps) {
+  const [items, setItems] = useState<CartItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const addItem = (newItem: CartItem) => {
+    if (newItem.quantity < 1) {
+      toast.error(
+        `Unable to add "${newItem.name}" (${newItem.size}) to the cart since the quantity is less than one`,
+      );
+      return;
+    }
+
+    setItems((currentItems) => {
+      let updatedItems: CartItem[];
+      const idx = currentItems.findIndex(
+        (cartItem) => cartItem.sockVariantId === newItem.sockVariantId,
+      );
+
+      if (idx === -1) {
+        updatedItems = [...currentItems, { ...newItem }];
+      } else {
+        const currentQuantity = currentItems[idx].quantity;
+        updatedItems = [
+          ...currentItems.slice(0, idx),
+          {
+            ...currentItems[idx],
+            quantity: currentQuantity + newItem.quantity,
+          },
+          ...currentItems.slice(idx + 1),
+        ];
+      }
+
+      return updatedItems;
+    });
+
+    toast.success(
+      `Added ${newItem.quantity}x "${newItem.name}" (${newItem.size})`,
+    );
+  };
+
+  const removeItem = (item: CartItem) => {
+    updateItem(item.sockVariantId, { ...item, quantity: 0 });
+  };
+
+  const updateItem = (sockVariantId: number, updatedItem: CartItem) => {
+    if (updatedItem.quantity < 0) {
+      toast.error("Unable to set an item's quantity to a value less than zero");
+      return;
+    }
+
+    setItems((currentItems) => {
+      const idx = currentItems.findIndex(
+        (cartItem) => cartItem.sockVariantId === sockVariantId,
+      );
+
+      if (idx === -1) {
+        console.error(
+          `"${updatedItem.name}" (${updatedItem.size}) is not in the cart`,
+        );
+        return currentItems;
+      }
+
+      let updatedItems: CartItem[];
+      if (updatedItem.quantity === 0) {
+        updatedItems = currentItems.filter(
+          (cartItem) => cartItem.sockVariantId !== sockVariantId,
+        );
+      } else {
+        updatedItems = [...currentItems];
+        updatedItems[idx] = { ...updatedItem };
+      }
+
+      if (updatedItems.length === 0) {
+        localStorage.removeItem(LOCAL_STORAGE_CART_ITEMS_KEY);
+      }
+
+      return updatedItems;
+    });
+  };
+
+  const empty = () => {
+    setItems([]);
+    localStorage.removeItem(LOCAL_STORAGE_CART_ITEMS_KEY);
+  };
+
+  const saveToStorage = () => {
+    if (items.length > 0) {
+      localStorage.setItem(LOCAL_STORAGE_CART_ITEMS_KEY, JSON.stringify(items));
+    }
+  };
+
+  const loadFromStorage = () => {
+    const stringifiedStoredItems = localStorage.getItem(
+      LOCAL_STORAGE_CART_ITEMS_KEY,
+    );
+
+    if (stringifiedStoredItems) {
+      try {
+        const storedItems = JSON.parse(stringifiedStoredItems);
+        const parsedItems = cartItemListSchema.parse(storedItems);
+        setItems(parsedItems);
+      } catch {
+        toast.error(
+          "Invalid cart items were found in local storage, unable to restore the cart",
+        );
+        empty();
+      }
+    }
+  };
+
+  useEffect(() => {
+    loadFromStorage();
+    setIsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    saveToStorage();
+  }, [JSON.stringify(items)]);
+
+  return (
+    <CartContext.Provider
+      value={{
+        items,
+        addItem,
+        removeItem,
+        updateItem,
+        empty,
+        isLoading,
+      }}
+    >
+      {children}
+    </CartContext.Provider>
+  );
+}
+
+export const useCart = (): CartContextType => {
+  const context = useContext(CartContext);
+  if (!context) {
+    throw new Error("useCart must be used within an CartProvider");
+  }
+  return context;
+};

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -6,9 +6,9 @@ import { Toaster } from "react-hot-toast";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import AuthProtectedRoutes from "./components/AuthProtectedRoutes";
-import CartDemo from "./components/CartDemo";
 import NotFound from "./components/NotFound";
 import UnderConstruction from "./components/UnderConstruction";
+import CartDemo from "./components/dev/CartDemo";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { AuthProvider } from "./context/AuthContext";
 import { CartProvider } from "./context/CartContext";
@@ -47,10 +47,6 @@ createRoot(document.getElementById("root")!).render(
                     path="cart/checkout/payment-canceled"
                     element={<PaymentCanceledPage />}
                   />
-                  {/* TODO: remove after testing */}
-                  {process.env.NODE_ENV !== "production" && (
-                    <Route path="cart-demo" element={<CartDemo />} />
-                  )}
 
                   {/* -- Post MVP -- */}
                   <Route
@@ -99,6 +95,13 @@ createRoot(document.getElementById("root")!).render(
                 </Route>
 
                 <Route path="*" element={<NotFound />} />
+
+                {/* --- Development only routes --- */}
+                {process.env.NODE_ENV !== "production" && (
+                  <Route path="/dev">
+                    <Route path="cart-demo" element={<CartDemo />} />
+                  </Route>
+                )}
               </Routes>
             </TooltipProvider>
           </AuthProvider>

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -6,6 +6,7 @@ import { Toaster } from "react-hot-toast";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import AuthProtectedRoutes from "./components/AuthProtectedRoutes";
+import CartDemo from "./components/CartDemo";
 import NotFound from "./components/NotFound";
 import UnderConstruction from "./components/UnderConstruction";
 import { TooltipProvider } from "./components/ui/tooltip";
@@ -46,6 +47,10 @@ createRoot(document.getElementById("root")!).render(
                     path="cart/checkout/payment-canceled"
                     element={<PaymentCanceledPage />}
                   />
+                  {/* TODO: remove after testing */}
+                  {process.env.NODE_ENV !== "production" && (
+                    <Route path="cart-demo" element={<CartDemo />} />
+                  )}
 
                   {/* -- Post MVP -- */}
                   <Route

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -10,6 +10,7 @@ import NotFound from "./components/NotFound";
 import UnderConstruction from "./components/UnderConstruction";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { AuthProvider } from "./context/AuthContext";
+import { CartProvider } from "./context/CartContext";
 import "./index.css";
 import AdminLayout from "./layouts/AdminLayout";
 import RootLayout from "./layouts/RootLayout";
@@ -27,80 +28,82 @@ const queryClient = new QueryClient();
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AuthProvider>
-          <TooltipProvider>
-            <Routes>
-              {/* ----- User facing routes (no auth) ----- */}
-              <Route path="/" element={<RootLayout />}>
-                <Route index element={<Navigate to="/home" replace />} />
-                <Route path="home" element={<HomePage />} />
-                <Route path="cart" element={<CartPage />} />
-                <Route
-                  path="cart/checkout/order-confirmation"
-                  element={<OrderConfirmationPage />}
-                />
-                <Route
-                  path="cart/checkout/payment-canceled"
-                  element={<PaymentCanceledPage />}
-                />
-
-                {/* -- Post MVP -- */}
-                <Route
-                  path="about-us"
-                  element={<UnderConstruction pageName="About us" />}
-                />
-                <Route
-                  path="careers"
-                  element={<UnderConstruction pageName="Careers" />}
-                />
-                <Route
-                  path="support"
-                  element={<UnderConstruction pageName="Support" />}
-                />
-                <Route
-                  path="privacy-policy"
-                  element={<UnderConstruction pageName="Privacy policy" />}
-                />
-                <Route
-                  path="terms-of-service"
-                  element={<UnderConstruction pageName="Terms of service" />}
-                />
-
-                <Route path="*" element={<NotFound />} />
-              </Route>
-              <Route path="/admin/login" element={<AdminLoginPage />} />
-
-              {/* ----- Admin dashboard ----- */}
-              <Route element={<AuthProtectedRoutes />}>
-                <Route path="/admin" element={<AdminLayout />}>
+      <CartProvider>
+        <BrowserRouter>
+          <AuthProvider>
+            <TooltipProvider>
+              <Routes>
+                {/* ----- User facing routes (no auth) ----- */}
+                <Route path="/" element={<RootLayout />}>
+                  <Route index element={<Navigate to="/home" replace />} />
+                  <Route path="home" element={<HomePage />} />
+                  <Route path="cart" element={<CartPage />} />
                   <Route
-                    index
-                    element={<Navigate to="/admin/home" replace />}
+                    path="cart/checkout/order-confirmation"
+                    element={<OrderConfirmationPage />}
                   />
-                  {/* For MVP, the inventory page will acts as the home page. */}
                   <Route
-                    path="home"
-                    element={<Navigate to="/admin/inventory" replace />}
+                    path="cart/checkout/payment-canceled"
+                    element={<PaymentCanceledPage />}
                   />
-                  <Route path="inventory" element={<AdminInventoryPage />} />
-                  <Route path="orders" element={<AdminOrdersPage />} />
-                  <Route path="profile" element={<AdminProfilePage />} />
+
+                  {/* -- Post MVP -- */}
+                  <Route
+                    path="about-us"
+                    element={<UnderConstruction pageName="About us" />}
+                  />
+                  <Route
+                    path="careers"
+                    element={<UnderConstruction pageName="Careers" />}
+                  />
+                  <Route
+                    path="support"
+                    element={<UnderConstruction pageName="Support" />}
+                  />
+                  <Route
+                    path="privacy-policy"
+                    element={<UnderConstruction pageName="Privacy policy" />}
+                  />
+                  <Route
+                    path="terms-of-service"
+                    element={<UnderConstruction pageName="Terms of service" />}
+                  />
 
                   <Route path="*" element={<NotFound />} />
                 </Route>
-              </Route>
+                <Route path="/admin/login" element={<AdminLoginPage />} />
 
-              <Route path="*" element={<NotFound />} />
-            </Routes>
-          </TooltipProvider>
-        </AuthProvider>
-      </BrowserRouter>
+                {/* ----- Admin dashboard ----- */}
+                <Route element={<AuthProtectedRoutes />}>
+                  <Route path="/admin" element={<AdminLayout />}>
+                    <Route
+                      index
+                      element={<Navigate to="/admin/home" replace />}
+                    />
+                    {/* For MVP, the inventory page will acts as the home page. */}
+                    <Route
+                      path="home"
+                      element={<Navigate to="/admin/inventory" replace />}
+                    />
+                    <Route path="inventory" element={<AdminInventoryPage />} />
+                    <Route path="orders" element={<AdminOrdersPage />} />
+                    <Route path="profile" element={<AdminProfilePage />} />
 
-      <Toaster position="top-right" />
-      {process.env.NODE_ENV !== "production" && (
-        <ReactQueryDevtools initialIsOpen={false} />
-      )}
+                    <Route path="*" element={<NotFound />} />
+                  </Route>
+                </Route>
+
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </TooltipProvider>
+          </AuthProvider>
+        </BrowserRouter>
+
+        <Toaster position="top-right" />
+        {process.env.NODE_ENV !== "production" && (
+          <ReactQueryDevtools initialIsOpen={false} />
+        )}
+      </CartProvider>
     </QueryClientProvider>
   </StrictMode>,
 );

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -15,6 +15,7 @@ import AdminLayout from "./layouts/AdminLayout";
 import RootLayout from "./layouts/RootLayout";
 import CartPage from "./pages/CartPage";
 import HomePage from "./pages/HomePage";
+import OrderConfirmationPage from "./pages/OrderConfirmationPage";
 import PaymentCanceledPage from "./pages/PaymentCanceledPage";
 import AdminInventoryPage from "./pages/admin/AdminInventoryPage";
 import AdminLoginPage from "./pages/admin/AdminLoginPage";
@@ -35,6 +36,10 @@ createRoot(document.getElementById("root")!).render(
                 <Route index element={<Navigate to="/home" replace />} />
                 <Route path="home" element={<HomePage />} />
                 <Route path="cart" element={<CartPage />} />
+                <Route
+                  path="cart/checkout/order-confirmation"
+                  element={<OrderConfirmationPage />}
+                />
                 <Route
                   path="cart/checkout/payment-canceled"
                   element={<PaymentCanceledPage />}

--- a/web-client/src/main.tsx
+++ b/web-client/src/main.tsx
@@ -15,6 +15,7 @@ import AdminLayout from "./layouts/AdminLayout";
 import RootLayout from "./layouts/RootLayout";
 import CartPage from "./pages/CartPage";
 import HomePage from "./pages/HomePage";
+import PaymentCanceledPage from "./pages/PaymentCanceledPage";
 import AdminInventoryPage from "./pages/admin/AdminInventoryPage";
 import AdminLoginPage from "./pages/admin/AdminLoginPage";
 import AdminOrdersPage from "./pages/admin/AdminOrdersPage";
@@ -34,6 +35,10 @@ createRoot(document.getElementById("root")!).render(
                 <Route index element={<Navigate to="/home" replace />} />
                 <Route path="home" element={<HomePage />} />
                 <Route path="cart" element={<CartPage />} />
+                <Route
+                  path="cart/checkout/payment-canceled"
+                  element={<PaymentCanceledPage />}
+                />
 
                 {/* -- Post MVP -- */}
                 <Route

--- a/web-client/src/pages/OrderConfirmationPage.tsx
+++ b/web-client/src/pages/OrderConfirmationPage.tsx
@@ -3,6 +3,7 @@ import GenericError from "@/components/GenericError";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
 import { SESSION_ID_QUERY_PARAM } from "@/shared/constants";
 import { toShippingAddress } from "@/shared/utils/strings";
 import dayjs from "dayjs";
@@ -31,13 +32,17 @@ export default function OrderConfirmationPage() {
   } = useGetStripeOrderConfirmation(sessionId);
 
   if (isLoading) {
-    return <div className="py-10">Loading...</div>;
+    return (
+      <div className="py-10">
+        <LoadingSkeleton />
+      </div>
+    );
   }
 
   if (isError) {
     return (
       <div className="py-10">
-        <GenericError message={error.message} />
+        <GenericError stackTrace={error.stack} />
       </div>
     );
   }
@@ -120,3 +125,63 @@ export default function OrderConfirmationPage() {
     </section>
   );
 }
+
+const LoadingSkeleton = () => {
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 px-4">
+      <div className="text-center">
+        <div className="mb-4 inline-flex items-center justify-center">
+          <Skeleton className="h-24 w-24 rounded-full" />
+        </div>
+        <Skeleton className="mb-2 h-8 w-3/4" />
+        <Skeleton className="h-6 w-1/2" />
+      </div>
+
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-8 w-1/3" />
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          <section className="grid grid-cols-2 gap-6">
+            <div>
+              <Skeleton className="h-6 w-1/2" />
+            </div>
+
+            <div>
+              <Skeleton className="h-6 w-1/2" />
+            </div>
+          </section>
+          <Separator />
+
+          <section>
+            <h3 className="mb-2">
+              <Skeleton className="h-8 w-1/3" />
+            </h3>
+            <div className="space-y-2">
+              <Skeleton className="h-6 w-full" />
+              <Skeleton className="h-6 w-2/3" />
+            </div>
+          </section>
+          <Separator />
+
+          <section className="flex justify-between">
+            <Skeleton className="h-6 w-1/3" />
+          </section>
+
+          <section>
+            <h3 className="mb-2">
+              <Skeleton className="h-8 w-1/3" />
+            </h3>
+            <Skeleton className="h-6 w-3/4" />
+          </section>
+        </CardContent>
+      </Card>
+
+      <div>
+        <Skeleton className="h-6 w-2/3" />
+        <Skeleton className="mt-4 h-10 w-1/4" />
+      </div>
+    </div>
+  );
+};

--- a/web-client/src/pages/OrderConfirmationPage.tsx
+++ b/web-client/src/pages/OrderConfirmationPage.tsx
@@ -42,7 +42,10 @@ export default function OrderConfirmationPage() {
   if (isError) {
     return (
       <div className="py-10">
-        <GenericError stackTrace={error.stack} />
+        <GenericError
+          message="We were unable to fetch the order confirmation."
+          stackTrace={error.stack}
+        />
       </div>
     );
   }

--- a/web-client/src/pages/OrderConfirmationPage.tsx
+++ b/web-client/src/pages/OrderConfirmationPage.tsx
@@ -1,4 +1,5 @@
 import { useGetStripeOrderConfirmation } from "@/api/cart/queries";
+import GenericError from "@/components/GenericError";
 import { SESSION_ID_QUERY_PARAM } from "@/shared/constants";
 import { useSearchParams } from "react-router-dom";
 
@@ -8,7 +9,13 @@ export default function OrderConfirmationPage() {
   const sessionId = params.get(SESSION_ID_QUERY_PARAM);
 
   if (!sessionId) {
-    return <>No session ID found!</>;
+    return (
+      <div className="mt-10">
+        <GenericError
+          message={`Unable to retrieve the '${SESSION_ID_QUERY_PARAM}' query parameter.`}
+        />
+      </div>
+    );
   }
 
   const {

--- a/web-client/src/pages/OrderConfirmationPage.tsx
+++ b/web-client/src/pages/OrderConfirmationPage.tsx
@@ -14,6 +14,13 @@ export default function OrderConfirmationPage() {
   const [params] = useSearchParams();
 
   const sessionId = params.get(SESSION_ID_QUERY_PARAM);
+  const {
+    data: orderConfirmation,
+    isLoading,
+    isError,
+    error,
+  } = useGetStripeOrderConfirmation(sessionId);
+
   if (!sessionId) {
     return (
       <div className="py-10">
@@ -25,13 +32,6 @@ export default function OrderConfirmationPage() {
       </div>
     );
   }
-
-  const {
-    data: orderConfirmation,
-    isLoading,
-    isError,
-    error,
-  } = useGetStripeOrderConfirmation(sessionId);
 
   if (isLoading) {
     return (

--- a/web-client/src/pages/OrderConfirmationPage.tsx
+++ b/web-client/src/pages/OrderConfirmationPage.tsx
@@ -1,0 +1,34 @@
+import { useGetStripeOrderConfirmation } from "@/api/cart/queries";
+import { SESSION_ID_QUERY_PARAM } from "@/shared/constants";
+import { useSearchParams } from "react-router-dom";
+
+export default function OrderConfirmationPage() {
+  const [params] = useSearchParams();
+
+  const sessionId = params.get(SESSION_ID_QUERY_PARAM);
+
+  if (!sessionId) {
+    return <>No session ID found!</>;
+  }
+
+  const {
+    data: orderConfirmation,
+    isLoading,
+    isError,
+    error,
+  } = useGetStripeOrderConfirmation(sessionId);
+
+  return (
+    <>
+      <p>order confirmation: {sessionId}</p>
+
+      {isLoading ? (
+        <>Loading...</>
+      ) : isError ? (
+        <>Error: {error.message}</>
+      ) : (
+        <>{JSON.stringify(orderConfirmation)}</>
+      )}
+    </>
+  );
+}

--- a/web-client/src/pages/OrderConfirmationPage.tsx
+++ b/web-client/src/pages/OrderConfirmationPage.tsx
@@ -1,16 +1,21 @@
 import { useGetStripeOrderConfirmation } from "@/api/cart/queries";
 import GenericError from "@/components/GenericError";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 import { SESSION_ID_QUERY_PARAM } from "@/shared/constants";
-import { useSearchParams } from "react-router-dom";
+import { toShippingAddress } from "@/shared/utils/strings";
+import dayjs from "dayjs";
+import { Check } from "lucide-react";
+import { Link, useSearchParams } from "react-router-dom";
 
 export default function OrderConfirmationPage() {
   const [params] = useSearchParams();
 
   const sessionId = params.get(SESSION_ID_QUERY_PARAM);
-
   if (!sessionId) {
     return (
-      <div className="mt-10">
+      <div className="py-10">
         <GenericError
           message={`Unable to retrieve the '${SESSION_ID_QUERY_PARAM}' query parameter.`}
         />
@@ -25,17 +30,93 @@ export default function OrderConfirmationPage() {
     error,
   } = useGetStripeOrderConfirmation(sessionId);
 
-  return (
-    <>
-      <p>order confirmation: {sessionId}</p>
+  if (isLoading) {
+    return <div className="py-10">Loading...</div>;
+  }
 
-      {isLoading ? (
-        <>Loading...</>
-      ) : isError ? (
-        <>Error: {error.message}</>
-      ) : (
-        <>{JSON.stringify(orderConfirmation)}</>
-      )}
-    </>
+  if (isError) {
+    return (
+      <div className="py-10">
+        <GenericError message={error.message} />
+      </div>
+    );
+  }
+
+  return (
+    <section className="bg-background px-4 py-10 md:px-8">
+      <div className="mx-auto max-w-3xl space-y-8">
+        <div className="text-center">
+          <div className="mb-4 inline-flex h-24 w-24 items-center justify-center rounded-full bg-green-100">
+            <Check className="h-12 w-12 text-green-600" />
+          </div>
+          <h1 className="mb-2 text-3xl font-bold">Order confirmed!</h1>
+          <p className="text-xl text-muted-foreground">
+            Thank you for your purchase.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-2xl font-semibold">
+              Order details
+            </CardTitle>
+          </CardHeader>
+
+          <CardContent className="space-y-4">
+            <section className="grid grid-cols-2 gap-6">
+              <div>
+                <p className="text-sm text-gray-600">Invoice #:</p>
+                <p className="font-medium">
+                  {orderConfirmation!.invoiceNumber}
+                </p>
+              </div>
+
+              <div>
+                <p className="text-sm text-gray-600">Order date:</p>
+                <p className="font-medium">
+                  {dayjs(orderConfirmation!.createdAt).format("MMMM D, YYYY")}
+                </p>
+              </div>
+            </section>
+            <Separator />
+
+            <section>
+              <h3 className="mb-2 font-semibold">Items ordered:</h3>
+              {orderConfirmation!.items.map((item) => (
+                <div
+                  key={item.sockVariantId}
+                  className="mb-2 flex justify-between"
+                >
+                  <span>
+                    {item.quantity}x {item.name} ({item.size})
+                  </span>
+                  <span>${(item.quantity * item.price).toFixed(2)}</span>
+                </div>
+              ))}
+            </section>
+            <Separator />
+
+            <section className="flex justify-between font-semibold">
+              <span>Total:</span>
+              <span>${orderConfirmation!.total.toFixed(2)}</span>
+            </section>
+
+            <section>
+              <h3 className="mb-2 font-semibold">Shipping address:</h3>
+              <p>{toShippingAddress(orderConfirmation!.address)}</p>
+            </section>
+          </CardContent>
+        </Card>
+
+        <div className="text-center">
+          <p className="mb-4">
+            We've sent a confirmation email to your registered email address.
+          </p>
+          <Button asChild>
+            <Link to="/">Continue shopping</Link>
+          </Button>
+        </div>
+      </div>
+    </section>
   );
 }

--- a/web-client/src/pages/OrderConfirmationPage.tsx
+++ b/web-client/src/pages/OrderConfirmationPage.tsx
@@ -18,7 +18,9 @@ export default function OrderConfirmationPage() {
     return (
       <div className="py-10">
         <GenericError
-          message={`Unable to retrieve the '${SESSION_ID_QUERY_PARAM}' query parameter.`}
+          message="We are unable to retrieve the order confirmation."
+          stackTrace={`Missing or empty '${SESSION_ID_QUERY_PARAM}' query parameter.`}
+          showRefresh={false}
         />
       </div>
     );

--- a/web-client/src/pages/PaymentCanceledPage.tsx
+++ b/web-client/src/pages/PaymentCanceledPage.tsx
@@ -11,8 +11,8 @@ import { Link } from "react-router-dom";
 
 export default function PaymentCanceledPage() {
   return (
-    <div className="mt-10 flex items-center justify-center bg-background px-4">
-      <Card className="w-full max-w-xl">
+    <div className="flex items-center justify-center bg-background px-4 py-10">
+      <Card className="w-full max-w-3xl">
         <CardHeader className="text-center">
           <div className="mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full bg-destructive/10">
             <AlertCircle className="h-12 w-12 text-destructive" />
@@ -20,14 +20,14 @@ export default function PaymentCanceledPage() {
           <CardTitle className="text-2xl font-bold">
             Payment cancelled
           </CardTitle>
-        </CardHeader>
-
-        <CardContent className="space-y-4">
           <p className="text-center text-muted-foreground">
             We're sorry, but your payment was not successful. This could be due
             to insufficient funds, an expired card, or other issues with your
             payment method.
           </p>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
           <div className="rounded-lg bg-muted p-4">
             <h3 className="mb-2 font-semibold">What you can do next:</h3>
             <ul className="list-inside list-disc space-y-1 text-sm text-muted-foreground">

--- a/web-client/src/pages/PaymentCanceledPage.tsx
+++ b/web-client/src/pages/PaymentCanceledPage.tsx
@@ -1,0 +1,57 @@
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { AlertCircle, ArrowLeft, MessageCircle } from "lucide-react";
+import { Link } from "react-router-dom";
+
+export default function PaymentCanceledPage() {
+  return (
+    <div className="mt-10 flex items-center justify-center bg-background px-4">
+      <Card className="w-full max-w-xl">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full bg-destructive/10">
+            <AlertCircle className="h-12 w-12 text-destructive" />
+          </div>
+          <CardTitle className="text-2xl font-bold">
+            Payment cancelled
+          </CardTitle>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          <p className="text-center text-muted-foreground">
+            We're sorry, but your payment was not successful. This could be due
+            to insufficient funds, an expired card, or other issues with your
+            payment method.
+          </p>
+          <div className="rounded-lg bg-muted p-4">
+            <h3 className="mb-2 font-semibold">What you can do next:</h3>
+            <ul className="list-inside list-disc space-y-1 text-sm text-muted-foreground">
+              <li>Check your payment details and try again</li>
+              <li>Use a different payment method</li>
+              <li>Contact your bank if the issue persists</li>
+              <li>Reach out to our support team for assistance</li>
+            </ul>
+          </div>
+        </CardContent>
+
+        <CardFooter className="flex flex-col space-y-2">
+          <Button className="w-full" asChild>
+            <Link to="/support">
+              <MessageCircle className="mr-2 h-4 w-4" /> Contact support
+            </Link>
+          </Button>
+          <Button variant="ghost" className="w-full" asChild>
+            <Link to="/">
+              <ArrowLeft className="mr-2 h-4 w-4" /> Return to home
+            </Link>
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/web-client/src/shared/constants.ts
+++ b/web-client/src/shared/constants.ts
@@ -1,5 +1,6 @@
 // Local storage
 export const LOCAL_STORAGE_AUTH_TOKEN_KEY = "token";
+export const LOCAL_STORAGE_CART_ITEMS_KEY = "cartItems";
 
 // URLs
 export const PROJECT_GITHUB_URL = "https://github.com/sockify/sockify";

--- a/web-client/src/shared/constants.ts
+++ b/web-client/src/shared/constants.ts
@@ -3,3 +3,6 @@ export const LOCAL_STORAGE_AUTH_TOKEN_KEY = "token";
 
 // URLs
 export const PROJECT_GITHUB_URL = "https://github.com/sockify/sockify";
+
+// Query params
+export const SESSION_ID_QUERY_PARAM = "session_id";

--- a/web-client/src/shared/utils/strings.ts
+++ b/web-client/src/shared/utils/strings.ts
@@ -1,7 +1,7 @@
-import { Address } from "@/api/cart/model";
+import { OrderAddress } from "@/api/orders/model";
 
 // Converts an `Address` type to a combined shipping address string
-export function toShippingAddress(address: Address): string {
+export function toShippingAddress(address: OrderAddress): string {
   // TODO: add city
   return `${address.street}${address.aptUnit && `, Apt/Unit ${address.aptUnit}`}, ${address.state}, ${address.zipcode}`;
 }

--- a/web-client/src/shared/utils/strings.ts
+++ b/web-client/src/shared/utils/strings.ts
@@ -1,0 +1,7 @@
+import { Address } from "@/api/cart/model";
+
+// Converts an `Address` type to a combined shipping address string
+export function toShippingAddress(address: Address): string {
+  // TODO: add city
+  return `${address.street}${address.aptUnit && `, Apt/Unit ${address.aptUnit}`}, ${address.state}, ${address.zipcode}`;
+}

--- a/web-client/src/shared/utils/strings.ts
+++ b/web-client/src/shared/utils/strings.ts
@@ -5,3 +5,11 @@ export function toShippingAddress(address: Address): string {
   // TODO: add city
   return `${address.street}${address.aptUnit && `, Apt/Unit ${address.aptUnit}`}, ${address.state}, ${address.zipcode}`;
 }
+
+// Truncates a string to a limit number of characters.
+export function truncate(str: string, limit: number, separator = "...") {
+  if (str.length <= limit) {
+    return str;
+  }
+  return str.substring(0, limit) + separator;
+}


### PR DESCRIPTION
## Description

Users are now able to see their order confirmation information within the UI.

## Changes

- Integrates the models, queries and services need to hit `GET /cart/checkout/stripe-confirmation/{session_id}` endpoint
- Custom loading and error states
- Adds a `GenericError` component to use throughout the app.
- Adds the `CartContext` and a demo at `/dev/cart-demo`

## Screenshots/demo
### Main UI

<img width="1291" alt="image" src="https://github.com/user-attachments/assets/07d86623-b5e2-4598-b387-dbd55c75aa91">

### Loading state

![image](https://github.com/user-attachments/assets/7da83153-0d5a-4402-adc3-d27680f0c03d)

### Error state

![image](https://github.com/user-attachments/assets/5e71aa35-2156-4889-85ee-c9efd47d3ca1)


### Demo (from Stripe checkout to our UI with order confirmation)
![Kapture 2024-10-16 at 21 47 27](https://github.com/user-attachments/assets/89d4b931-8097-4bc7-8f04-4e1bc1614a18)

### Cart demo `/dev/cart-demo`

<img width="1440" alt="Screenshot 2024-10-17 at 8 04 55 AM" src="https://github.com/user-attachments/assets/a806ad7c-73d7-4c39-9947-8381991cddf6">


## Related issues

Closes #86, #96
