### PR TITLE
Create useGetOrders in orders service

### DIFF
--- a/web-client/src/api/orders/model.ts
+++ b/web-client/src/api/orders/model.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 
 export const orderAddressSchema = z.object({
   street: z.string(),
-  aptUnit: z.string(),
+  aptUnit: z.string().nullable(),
   //   city: z.string(),
   state: z.enum([
     "AL",
@@ -102,3 +102,11 @@ export const orderSchema = z.object({
   createdAt: z.string().optional(),
 });
 export type Order = z.infer<typeof orderSchema>;
+
+export const ordersPaginatedResponseSchema = z.object({
+  items: z.array(orderSchema),
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+});
+export type OrdersPaginatedResponse = z.infer<typeof ordersPaginatedResponseSchema>;

--- a/web-client/src/api/orders/queries.ts
+++ b/web-client/src/api/orders/queries.ts
@@ -1,6 +1,6 @@
 import { UseQueryResult, queryOptions, useQuery } from "@tanstack/react-query";
 
-import { Order } from "./model";
+import { Order, OrdersPaginatedResponse, OrderStatus } from "./model";
 import { HttpOrderService } from "./service";
 
 const orderService = new HttpOrderService();
@@ -29,4 +29,21 @@ export function useGetOrderByInvoice(
   invoiceNumber: string,
 ): UseQueryResult<Order> {
   return useQuery(useGetOrderByInvoiceOptions(invoiceNumber));
+}
+
+export function useGetOrdersOptions(status: OrderStatus, limit: number, offset: number, enabled = true) {
+  return queryOptions({
+    queryKey: ["orders", { status, limit, offset }],
+    queryFn: () => orderService.getOrders(status, limit, offset),
+    enabled,
+  });
+}
+
+export function useGetOrders(
+  status: OrderStatus,
+  limit: number,
+  offset: number,
+  enabled = true,
+): UseQueryResult<OrdersPaginatedResponse> {
+  return useQuery(useGetOrdersOptions(status, limit, offset, enabled));
 }

--- a/web-client/src/api/orders/service.ts
+++ b/web-client/src/api/orders/service.ts
@@ -1,10 +1,11 @@
 import axiosInstance from "@/shared/axios";
 
-import { Order, orderSchema } from "./model";
+import { Order, orderSchema, OrdersPaginatedResponse, OrderStatus, ordersPaginatedResponseSchema } from "./model";
 
 export interface OrderService {
   getOrderById(orderId: number): Promise<Order>;
   getOrderByInvoice(invoiceNumber: string): Promise<Order>;
+  getOrders(status: OrderStatus, limit: number, offset: number): Promise<OrdersPaginatedResponse>;
 }
 
 export class HttpOrderService implements OrderService {
@@ -18,5 +19,12 @@ export class HttpOrderService implements OrderService {
       `/api/v1/orders/invoice/${invoiceNumber}`,
     );
     return orderSchema.parse(data);
+  }
+
+  async getOrders(status: OrderStatus, limit: number, offset: number): Promise<OrdersPaginatedResponse> {
+    const { data } = await axiosInstance.get(`/api/v1/orders`, {
+      params: { status, limit, offset },
+    });
+    return ordersPaginatedResponseSchema.parse(data);
   }
 }


### PR DESCRIPTION
## Description

Created the API integration required to get all orders and get an individual order from the UI.

## Changes

- Added ordersPaginatedResponseSchema to model.ts
- Added useGetOrdersOptions and useGetOrders functions to queries.ts
- Added getOrders method to service.ts

## Screenshots/demo

Temporarily edited the AdminOrdersPage
<img width="1365" alt="image" src="https://github.com/user-attachments/assets/eea1275b-671e-42a3-ab60-39076202e56b">
Made it so it displays all the orders and details. (Unsure if this is what was wanted)


## Related issues

What issue(s) does this PR fix?
#80 
