### PR TITLE
Similar items

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -738,6 +738,38 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/socks/{sock_id}/similar-socks": {
+            "get": {
+                "description": "For now, it will retrieve the top 6 products that are not matching the sock_id passed in.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Inventory"
+                ],
+                "summary": "Retrieves the related products for a particular sock",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Sock ID",
+                        "name": "sock_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.SimilarSock"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1084,6 +1116,26 @@ const docTemplate = `{
                     "type": "string",
                     "maxLength": 16,
                     "minLength": 3
+                }
+            }
+        },
+        "types.SimilarSock": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "previewImageUrl": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "sockId": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/docs/swagger.json
+++ b/api/docs/swagger.json
@@ -731,6 +731,38 @@
                     }
                 }
             }
+        },
+        "/socks/{sock_id}/similar-socks": {
+            "get": {
+                "description": "For now, it will retrieve the top 6 products that are not matching the sock_id passed in.",
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Inventory"
+                ],
+                "summary": "Retrieves the related products for a particular sock",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Sock ID",
+                        "name": "sock_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/types.SimilarSock"
+                            }
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1077,6 +1109,26 @@
                     "type": "string",
                     "maxLength": 16,
                     "minLength": 3
+                }
+            }
+        },
+        "types.SimilarSock": {
+            "type": "object",
+            "properties": {
+                "createdAt": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "previewImageUrl": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "number"
+                },
+                "sockId": {
+                    "type": "integer"
                 }
             }
         },

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -230,6 +230,19 @@ definitions:
     - password
     - username
     type: object
+  types.SimilarSock:
+    properties:
+      createdAt:
+        type: string
+      name:
+        type: string
+      previewImageUrl:
+        type: string
+      price:
+        type: number
+      sockId:
+        type: integer
+    type: object
   types.Sock:
     properties:
       createdAt:
@@ -894,6 +907,28 @@ paths:
       security:
       - Bearer: []
       summary: Updates the details of a sock
+      tags:
+      - Inventory
+  /socks/{sock_id}/similar-socks:
+    get:
+      consumes:
+      - application/json
+      description: For now, it will retrieve the top 6 products that are not matching
+        the sock_id passed in.
+      parameters:
+      - description: Sock ID
+        in: path
+        name: sock_id
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/types.SimilarSock'
+            type: array
+      summary: Retrieves the related products for a particular sock
       tags:
       - Inventory
 securityDefinitions:

--- a/api/types/entities.go
+++ b/api/types/entities.go
@@ -83,3 +83,11 @@ type OrderUpdateCreator struct {
 	LastName  string `json:"lastname"`
 	Username  string `json:"username"`
 }
+
+type SimilarSock struct {
+	SockId          int     `json:"sockId"`
+	Name            string  `json:"name"`
+	Price           float64 `json:"price"`
+	PreviewImageURL string  `json:"previewImageUrl"`
+	CreatedAt       string  `json:"createdAt"`
+}

--- a/api/types/stores.go
+++ b/api/types/stores.go
@@ -22,6 +22,7 @@ type SockStore interface {
 	GetSockVariantByID(sockVariantID int) (*SockVariant, error)
 	GetSockVariantsByID(sockVariantIDs []int) ([]SockVariant, error)
 	UpdateSockVariantQuantity(sockVariantID int, newQuantity int) error
+	GetSimilarSocks(sockID int) ([]SimilarSock, error)
 }
 
 type OrderStore interface {

--- a/web-client/src/api/inventory/model.ts
+++ b/web-client/src/api/inventory/model.ts
@@ -38,3 +38,13 @@ export const socksPaginatedResponseSchema = z.object({
 export type SocksPaginatedResponse = z.infer<
   typeof socksPaginatedResponseSchema
 >;
+
+export const similarSockSchema = z.object({
+  sockId: z.number(),
+  name: z.string(),
+  price: z.number(),
+  previewImageUrl: z.string(),
+  createdAt: z.string(),
+});
+export type SimilarSock = z.infer<typeof similarSockSchema>;
+export const similarSockListSchema = z.array(similarSockSchema);

--- a/web-client/src/api/inventory/queries.ts
+++ b/web-client/src/api/inventory/queries.ts
@@ -1,6 +1,6 @@
 import { UseQueryResult, queryOptions, useQuery } from "@tanstack/react-query";
 
-import { Sock, SocksPaginatedResponse } from "./model";
+import { SimilarSock, Sock, SocksPaginatedResponse } from "./model";
 import { HttpInventoryService } from "./service";
 
 const sockService = new HttpInventoryService();
@@ -33,4 +33,16 @@ export function useGetSocks(
   enabled = true,
 ): UseQueryResult<SocksPaginatedResponse> {
   return useQuery(useGetSocksOptions(limit, offset, enabled));
+}
+
+export function useGetSimilarSocksOptions(sockId: number) {
+  return queryOptions({
+    queryKey: ["similar-socks", { sockId }],
+    queryFn: () => sockService.getSimilarSocks(sockId),
+  });
+}
+export function useGetSimilarSocks(
+  sockId: number,
+): UseQueryResult<SimilarSock[]> {
+  return useQuery(useGetSimilarSocksOptions(sockId));
 }

--- a/web-client/src/api/inventory/service.ts
+++ b/web-client/src/api/inventory/service.ts
@@ -1,8 +1,10 @@
 import axiosInstance from "@/shared/axios";
 
 import {
+  SimilarSock,
   Sock,
   SocksPaginatedResponse,
+  similarSockListSchema,
   sockSchema,
   socksPaginatedResponseSchema,
 } from "./model";
@@ -10,6 +12,7 @@ import {
 export interface InventoryService {
   getSockById(sockId: number): Promise<Sock>;
   getSocks(limit: number, offset: number): Promise<SocksPaginatedResponse>;
+  getSimilarSocks(sockId: number): Promise<SimilarSock[]>;
 }
 
 export class HttpInventoryService implements InventoryService {
@@ -26,5 +29,12 @@ export class HttpInventoryService implements InventoryService {
       params: { limit, offset },
     });
     return socksPaginatedResponseSchema.parse(data);
+  }
+
+  async getSimilarSocks(sockId: number): Promise<SimilarSock[]> {
+    const { data } = await axiosInstance.get(
+      `/api/v1/socks/${sockId}/similar-socks`,
+    );
+    return similarSockListSchema.parse(data);
   }
 }

--- a/web-client/src/pages/SockDetailsPage.tsx
+++ b/web-client/src/pages/SockDetailsPage.tsx
@@ -1,6 +1,6 @@
 import { CartItem } from "@/api/cart/model";
 import { SockVariant } from "@/api/inventory/model";
-import { useGetSockById } from "@/api/inventory/queries";
+import { useGetSimilarSocks, useGetSockById } from "@/api/inventory/queries";
 import GenericError from "@/components/GenericError";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -9,31 +9,12 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useCart } from "@/context/CartContext";
 import { NO_IMAGE_PLACEHOLDER } from "@/shared/constants";
 import { Heart, Minus, Plus, Share2, ShoppingCart, Star } from "lucide-react";
-import { useEffect, useState } from "react";
+import { ReactElement, useEffect, useState } from "react";
 import toast from "react-hot-toast";
 import { useNavigate, useParams } from "react-router-dom";
 
-// FIXME: remove dummy similar products
-const similarProducts = [
-  {
-    id: 1,
-    name: "Classic Black Socks",
-    price: 9.99,
-    imageUrl: "https://via.placeholder.com/300",
-  },
-  {
-    id: 2,
-    name: "Colorful Polka Dot Socks",
-    price: 11.99,
-    imageUrl: "https://via.placeholder.com/300",
-  },
-  {
-    id: 3,
-    name: "Warm Wool Socks",
-    price: 14.99,
-    imageUrl: "https://via.placeholder.com/300",
-  },
-];
+// Max number of similar socks shown
+const SIMILAR_SOCKS_LIMIT = 3;
 
 export default function SockDetailsPage() {
   const params = useParams();
@@ -43,7 +24,17 @@ export default function SockDetailsPage() {
   const sockIdStr = params["sockId"];
   const sockId = parseInt(sockIdStr!);
 
-  const { data: sock, isLoading, isError, error } = useGetSockById(sockId);
+  const {
+    data: sock,
+    isLoading: isLoadingSock,
+    isError: isErrorSock,
+    error: errorSock,
+  } = useGetSockById(sockId);
+  const {
+    data: similarSocks,
+    isLoading: isLoadingSimilarSocks,
+    isError: isErrorSimilarSocks,
+  } = useGetSimilarSocks(sockId);
 
   const [selectedVariant, setSelectedVariant] = useState<
     SockVariant | undefined
@@ -93,149 +84,154 @@ export default function SockDetailsPage() {
     }
   }, [sock]);
 
-  if (isLoading) {
-    return <ItemLoadingSkeleton />;
-  }
-
-  if (isError) {
-    return (
-      <GenericError
-        message={`Unable to load sock details for ID ${sockIdStr}`}
-        stackTrace={error.stack}
-      />
-    );
-  }
-
   return (
     <div className="mx-auto px-4 py-10 md:px-8">
-      <div className="flex flex-col space-y-8 md:flex-row md:space-x-8 md:space-y-0">
-        <div className="h-[512px] w-full md:w-1/2">
-          <img
-            src={sock!.previewImageUrl}
-            alt={sock!.name}
-            className="h-full w-full rounded object-cover"
-            onError={(e) => {
-              e.currentTarget.src = NO_IMAGE_PLACEHOLDER;
-            }}
-          />
-        </div>
-
-        <div className="w-full space-y-4 md:w-1/2">
-          <h1 className="text-3xl font-bold">{sock!.name}</h1>
-          <div className="flex items-center space-x-2">
-            {/* TODO: work on the review features */}
-            <div className="flex">
-              {[1, 2, 3, 4, 5].map((star) => (
-                <Star key={star} className="h-5 w-5 text-primary" />
-              ))}
-            </div>
-            <span className="text-sm text-muted-foreground">(0 reviews)</span>
+      {isLoadingSock ? (
+        <ItemLoadingSkeleton />
+      ) : isErrorSock ? (
+        <GenericError
+          message={`Unable to load sock details for ID ${sockIdStr}`}
+          stackTrace={errorSock.stack}
+        />
+      ) : (
+        <div className="flex flex-col space-y-8 md:flex-row md:space-x-8 md:space-y-0">
+          <div className="h-[512px] w-full md:w-1/2">
+            <img
+              src={sock!.previewImageUrl}
+              alt={sock!.name}
+              className="h-full w-full rounded object-cover"
+              onError={(e) => {
+                e.currentTarget.src = NO_IMAGE_PLACEHOLDER;
+              }}
+            />
           </div>
-          {isOutOfStock ? (
-            <Badge variant="destructive">Out of stock</Badge>
-          ) : (
-            <p className="text-xl text-muted-foreground">
-              ${selectedVariant?.price}
-            </p>
-          )}
-          <p>{sock!.description}</p>
 
-          {!isOutOfStock && (
-            <div className="my-4">
-              <label className="mb-1 block font-medium">Size</label>
-              <div className="flex space-x-4">
-                {sock!.variants.map((variant) => (
-                  <Button
-                    key={variant.id!}
-                    variant={`${selectedVariant?.size === variant.size ? "default" : "outline"}`}
-                    size="icon"
-                    onClick={() => handleSizeChange(variant)}
-                    className="min-w-12"
-                    disabled={variant.quantity < 1}
-                  >
-                    {variant.size}
-                  </Button>
+          <div className="w-full space-y-4 md:w-1/2">
+            <h1 className="text-3xl font-bold">{sock!.name}</h1>
+            <div className="flex items-center space-x-2">
+              {/* TODO: work on the review features */}
+              <div className="flex">
+                {[1, 2, 3, 4, 5].map((star) => (
+                  <Star key={star} className="h-5 w-5 text-primary" />
                 ))}
               </div>
+              <span className="text-sm text-muted-foreground">(0 reviews)</span>
             </div>
-          )}
+            {isOutOfStock ? (
+              <Badge variant="destructive">Out of stock</Badge>
+            ) : (
+              <p className="text-xl text-muted-foreground">
+                ${selectedVariant?.price}
+              </p>
+            )}
+            <p>{sock!.description}</p>
 
-          {!isOutOfStock && (
-            <div className="my-4">
-              <label className="mb-1 block font-medium">Quantity</label>
-              <div className="flex items-center space-x-2">
-                <Button
-                  variant="outline"
-                  size="icon"
-                  onClick={() =>
-                    setSelectedQuantity(Math.max(1, selectedQuantity - 1))
-                  }
-                  disabled={selectedQuantity === 1}
-                >
-                  <Minus size={16} />
-                  <span className="sr-only">Decrease quantity by 1</span>
-                </Button>
-                <div className="w-12 text-center">{selectedQuantity}</div>
-                <Button
-                  variant="outline"
-                  size="icon"
-                  onClick={() => setSelectedQuantity(selectedQuantity + 1)}
-                >
-                  <Plus size={16} />
-                  <span className="sr-only">Increase quantity by 1</span>
-                </Button>
+            {!isOutOfStock && (
+              <div className="my-4">
+                <label className="mb-1 block font-medium">Size</label>
+                <div className="flex space-x-4">
+                  {sock!.variants.map((variant) => (
+                    <Button
+                      key={variant.id!}
+                      variant={`${selectedVariant?.size === variant.size ? "default" : "outline"}`}
+                      size="icon"
+                      onClick={() => handleSizeChange(variant)}
+                      className="min-w-12"
+                      disabled={variant.quantity < 1}
+                    >
+                      {variant.size}
+                    </Button>
+                  ))}
+                </div>
               </div>
+            )}
+
+            {!isOutOfStock && (
+              <div className="my-4">
+                <label className="mb-1 block font-medium">Quantity</label>
+                <div className="flex items-center space-x-2">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() =>
+                      setSelectedQuantity(Math.max(1, selectedQuantity - 1))
+                    }
+                    disabled={selectedQuantity === 1}
+                  >
+                    <Minus size={16} />
+                    <span className="sr-only">Decrease quantity by 1</span>
+                  </Button>
+                  <div className="w-12 text-center">{selectedQuantity}</div>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => setSelectedQuantity(selectedQuantity + 1)}
+                  >
+                    <Plus size={16} />
+                    <span className="sr-only">Increase quantity by 1</span>
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            <div className="flex gap-2 pb-2 pt-4">
+              <Button
+                onClick={handleAddToCart}
+                className="w-full"
+                disabled={isOutOfStock}
+              >
+                <ShoppingCart className="h-8 w-8 pr-3" /> Add to cart
+              </Button>
+
+              {/* TODO: add the share and add to wishlist functionalities */}
+              <Button variant="outline" size="icon" disabled={true}>
+                <span className="sr-only">Add to wishlist</span>
+                <Heart className="h-4 w-4" />
+              </Button>
+              <Button variant="outline" size="icon" disabled={true}>
+                <Share2 className="h-4 w-4" />
+                <span className="sr-only">Share product</span>
+              </Button>
             </div>
-          )}
 
-          <div className="flex gap-2 pb-2 pt-4">
-            <Button
-              onClick={handleAddToCart}
-              className="w-full"
-              disabled={isOutOfStock}
-            >
-              <ShoppingCart className="h-8 w-8 pr-3" /> Add to cart
-            </Button>
-
-            {/* TODO: add the share and add to wishlist functionalities */}
-            <Button variant="outline" size="icon" disabled={true}>
-              <span className="sr-only">Add to wishlist</span>
-              <Heart className="h-4 w-4" />
-            </Button>
-            <Button variant="outline" size="icon" disabled={true}>
-              <Share2 className="h-4 w-4" />
-              <span className="sr-only">Share product</span>
-            </Button>
-          </div>
-
-          <div className="space-y-2 text-sm text-muted-foreground">
-            <p>Free shipping on orders over $50</p>
-            <p>30-day easy returns</p>
-            <p>Made in USA</p>
+            <div className="space-y-2 text-sm text-muted-foreground">
+              <p>Free shipping on orders over $50</p>
+              <p>30-day easy returns</p>
+              <p>Made in USA</p>
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       <div className="mt-12">
-        <h2 className="mb-4 text-2xl font-bold">Similar products</h2>
+        <h2 className="mb-4 text-2xl font-bold">Similar socks</h2>
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-          {similarProducts.map((product) => (
-            <Card key={product.id} className="p-4">
-              <img
-                src={product.imageUrl}
-                alt={product.name}
-                className="h-48 w-full rounded object-cover"
-              />
-              <h3 className="mt-4 text-lg font-semibold">{product.name}</h3>
-              <p className="text-gray-600">${product.price}</p>
-              <Button
-                className="mt-4 w-full"
-                onClick={() => handleViewProduct(product.id)}
-              >
-                View product
-              </Button>
-            </Card>
-          ))}
+          {isLoadingSimilarSocks ? (
+            <SimilarSocksSkeleton />
+          ) : isErrorSimilarSocks ? (
+            <GenericError message="Unable to load similar socks" />
+          ) : (
+            similarSocks!.slice(0, SIMILAR_SOCKS_LIMIT).map((sock) => (
+              <Card key={sock.sockId} className="p-4">
+                <img
+                  src={sock.previewImageUrl}
+                  alt={sock.name}
+                  className="h-48 w-full rounded object-cover"
+                  onError={(e) => {
+                    e.currentTarget.src = NO_IMAGE_PLACEHOLDER;
+                  }}
+                />
+                <h3 className="mt-4 text-lg font-semibold">{sock.name}</h3>
+                <p className="text-gray-600">${sock.price}</p>
+                <Button
+                  className="mt-4 w-full"
+                  onClick={() => handleViewProduct(sock.sockId)}
+                >
+                  View sock
+                </Button>
+              </Card>
+            ))
+          )}
         </div>
       </div>
     </div>
@@ -244,27 +240,45 @@ export default function SockDetailsPage() {
 
 function ItemLoadingSkeleton() {
   return (
-    <div className="mx-auto px-4 py-12 md:px-8">
-      <div className="flex flex-col space-y-8 md:flex-row md:space-x-8 md:space-y-0">
-        <div className="w-full md:w-1/2">
-          <Skeleton className="h-[512px] w-full rounded" />
-        </div>
+    <div className="flex flex-col space-y-8 md:flex-row md:space-x-8 md:space-y-0">
+      <div className="w-full md:w-1/2">
+        <Skeleton className="h-[512px] w-full rounded" />
+      </div>
 
-        <div className="w-full space-y-6 md:w-1/2">
-          <Skeleton className="h-10 w-3/4" />
-          <Skeleton className="h-6 w-1/4" />
-          <Skeleton className="h-24 w-full" />
+      <div className="w-full space-y-6 md:w-1/2">
+        <Skeleton className="h-10 w-3/4" />
+        <Skeleton className="h-6 w-1/4" />
+        <Skeleton className="h-24 w-full" />
 
-          <div className="my-4">
-            <Skeleton className="mb-3 h-5 w-20" />
-            <div className="flex space-x-4">
-              <Skeleton className="h-10 w-12" />
-              <Skeleton className="h-10 w-12" />
-              <Skeleton className="h-10 w-12" />
-            </div>
+        <div className="my-4">
+          <Skeleton className="mb-3 h-5 w-20" />
+          <div className="flex space-x-4">
+            <Skeleton className="h-10 w-12" />
+            <Skeleton className="h-10 w-12" />
+            <Skeleton className="h-10 w-12" />
           </div>
         </div>
       </div>
     </div>
   );
+}
+
+function SimilarSocksSkeleton() {
+  const renderItems = () => {
+    const items: ReactElement[] = [];
+    for (let i = 0; i < 3; i++) {
+      items.push(
+        <Card className="p-4">
+          <Skeleton className="h-48 w-full rounded" />
+          <div className="mt-4">
+            <Skeleton className="mb-2 h-6 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+          </div>
+        </Card>,
+      );
+    }
+    return items;
+  };
+
+  return renderItems();
 }


### PR DESCRIPTION
## Description

Create the API endpoint to get the similar items for a particular sock. Also, integrates the changes within the UI.

## Changes

- Add the `GET /socks/:id/similar-socks` API endpoint
- Integrates the changes within the `<SockDetailsPage />`

## Screenshots/demo

### Custom loading state

<img width="1440" alt="Screenshot 2024-11-06 at 12 22 31 PM" src="https://github.com/user-attachments/assets/ba03aae2-ecf6-4e20-b3eb-4649521dad63">

### Items shown (limited to 3)

<img width="1440" alt="Screenshot 2024-11-06 at 12 16 29 PM" src="https://github.com/user-attachments/assets/a9da69e3-e4a1-4fce-b481-f351af959f99">


## Related issues

Closes #110 
