### PR TITLE
feat: integrates the `Send Grid` email client to send order confirmations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ An e-commerce web app to sell custom socks.
 - **Admin dashboard:** <https://sockify-dev.up.railway.app/admin>
   - **Username:** `jdoe`
   - **Password:** `password`
+  - **Credit card:** `4242 4242 4242 4242`
 - **API docs:** <https://sockify-api-dev.up.railway.app/swagger/index.html>
 
 **Core team:** [Abel Aguillera](https://www.linkedin.com/in/abel-aguilera-09b65b249/), [Bora Dibra](https://www.linkedin.com/in/bora-dibra/), [Charlotte Williams](https://www.linkedin.com/in/charlotte-williams-761510185/), [Sebastian Nunez](https://www.linkedin.com/in/sebastian-nunez-profile/)
@@ -59,7 +60,7 @@ An e-commerce web app to sell custom socks.
   - **Payment processing:** [Stripe](https://stripe.com/)
   - **Blob storage:** [Firebase](https://firebase.google.com/)
   - **API Specification (UI):** [OpenAPI (Swagger)](https://github.com/swaggo/swag?tab=readme-ov-file)
-  - **Email client:** TBD
+  - **Email client:** [SendGrid](https://sendgrid.com/)
 - **Database:** [PostgreSQL](https://www.postgresql.org/)
 - **Hosting:** [Railway](https://railway.app/), [Docker Compose](https://docs.docker.com/compose/)
 - **Design:** [Figma](https://figma.com/)

--- a/api/config/env.go
+++ b/api/config/env.go
@@ -20,6 +20,7 @@ type Config struct {
 	JWTExpirationInSeconds int64
 	DisableAuth            bool
 	StripeAPIKey           string
+	SendGridAPIKey         string
 }
 
 // Envs is the global configuration for the application.
@@ -39,6 +40,7 @@ func initConfig() Config {
 		JWTExpirationInSeconds: getEnvInt("JWT_EXPIRATION_IN_SECONDS", FOUR_HOURS_IN_SECONDS),
 		DisableAuth:            getEnvBool("DISABLE_AUTH", false),
 		StripeAPIKey:           getEnv("STRIPE_API_KEY", "FIXME"),
+		SendGridAPIKey:         getEnv("SENDGRID_API_KEY", "FIXME"),
 	}
 }
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -31,6 +31,8 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/sendgrid/rest v2.6.9+incompatible // indirect
+	github.com/sendgrid/sendgrid-go v3.16.0+incompatible // indirect
 	github.com/swaggo/files v1.0.1 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/net v0.29.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -80,6 +80,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
+github.com/sendgrid/rest v2.6.9+incompatible h1:1EyIcsNdn9KIisLW50MKwmSRSK+ekueiEMJ7NEoxJo0=
+github.com/sendgrid/rest v2.6.9+incompatible/go.mod h1:kXX7q3jZtJXK5c5qK83bSGMdV6tsOE70KbHoqJls4lE=
+github.com/sendgrid/sendgrid-go v3.16.0+incompatible h1:i8eE6IMkiCy7vusSdacHHSBUpXyTcTXy/Rl9N9aZ/Qw=
+github.com/sendgrid/sendgrid-go v3.16.0+incompatible/go.mod h1:QRQt+LX/NmgVEvmdRw0VT/QgUn499+iza2FnDca9fg8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/api/routes/routes.go
+++ b/api/routes/routes.go
@@ -4,8 +4,11 @@ import (
 	"database/sql"
 
 	"github.com/gorilla/mux"
+	"github.com/sendgrid/sendgrid-go"
+	"github.com/sockify/sockify/config"
 	"github.com/sockify/sockify/services/admin"
 	"github.com/sockify/sockify/services/cart"
+	"github.com/sockify/sockify/services/email"
 	"github.com/sockify/sockify/services/inventory"
 	"github.com/sockify/sockify/services/newsletter"
 	"github.com/sockify/sockify/services/orders"
@@ -14,6 +17,9 @@ import (
 func Router(db *sql.DB) *mux.Router {
 	router := mux.NewRouter()
 	subrouter := router.PathPrefix("/api/v1").Subrouter()
+
+	client := sendgrid.NewSendClient(config.Envs.SendGridAPIKey)
+	emailService := email.NewService(client)
 
 	adminStore := admin.NewStore(db)
 	adminHandler := admin.NewHandler(adminStore)
@@ -27,7 +33,7 @@ func Router(db *sql.DB) *mux.Router {
 	orderHandler := orders.NewOrderHandler(orderStore)
 	orderHandler.RegisterRoutes(subrouter, adminStore)
 
-	cartHandler := cart.NewCartHandler(sockStore, orderStore)
+	cartHandler := cart.NewCartHandler(sockStore, orderStore, emailService)
 	cartHandler.RegisterRoutes(subrouter)
 
 	newsletterStore := newsletter.NewStore(db)

--- a/api/services/email/service.go
+++ b/api/services/email/service.go
@@ -1,0 +1,38 @@
+package email
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/sendgrid/sendgrid-go"
+	"github.com/sendgrid/sendgrid-go/helpers/mail"
+	"github.com/sockify/sockify/services/email/templates"
+	"github.com/sockify/sockify/types"
+	"github.com/sockify/sockify/utils"
+)
+
+type Service struct {
+	client *sendgrid.Client
+}
+
+func NewService(client *sendgrid.Client) Service {
+	return Service{client: client}
+}
+
+func (s *Service) SendOrderConfirmationEmail(toName string, toEmail string, order types.OrderConfirmation) error {
+	plainText, htmlContent := templates.CreateOrderConfirmationTemplate(order)
+
+	from := mail.NewEmail(utils.EmailSenderName, utils.NoReplyEmailAddress)
+	subject := fmt.Sprintf("Order confirmation (%s)", order.InvoiceNumber)
+	to := mail.NewEmail(toName, toEmail)
+	message := mail.NewSingleEmail(from, subject, to, plainText, htmlContent)
+
+	_, err := s.client.Send(message)
+	if err != nil {
+		log.Printf("Failed to send order confirmation for invoice: %s - Error: %v\n", order.InvoiceNumber, err)
+		return err
+	}
+
+	log.Printf("Sent email confirmation for invoice number: %v", order.InvoiceNumber)
+	return nil
+}

--- a/api/services/email/templates/order_confirmation.go
+++ b/api/services/email/templates/order_confirmation.go
@@ -1,0 +1,118 @@
+package templates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sockify/sockify/types"
+)
+
+func CreateOrderConfirmationTemplate(order types.OrderConfirmation) (plainText string, htmlContent string) {
+	// TODO: need to add "city" to address
+	aptUnit := ""
+	if order.Address.AptUnit != nil {
+		aptUnit = ", " + *order.Address.AptUnit
+	}
+
+	// TODO: remove disclaimers if actual store is set up
+	plainText = fmt.Sprintf(`
+  DISCLAIMER: this is a test confirmation, the order won't be fulfilled!
+  
+  Hello,
+
+  Thank you for your order!
+  
+  Invoice #: %s
+  Status: %s
+  Date: %s
+  
+  Shipping address:
+  %s%s
+  %s, %s
+  
+  Items:
+  %s
+  
+  Total: $%.2f
+  
+  Thank you for shopping with us!
+
+  Best regards,
+  Sockify team`,
+		order.InvoiceNumber,
+		order.Status,
+		order.CreatedAt,
+		order.Address.Street,
+		aptUnit,
+		order.Address.State,
+		order.Address.Zipcode,
+		formatItemsPlain(order.Items),
+		order.Total,
+	)
+
+	htmlContent = fmt.Sprintf(`<html>
+  <body>
+    <h2>Thank you for your order!</h2>
+    <h4>DISCLAIMER: this is a test confirmation, the order won't be fulfilled!</h4>
+    <p><strong>Invoice #:</strong> %s</p>
+    <p><strong>Status:</strong> %s</p>
+    <p><strong>Date:</strong> %s</p>
+
+    <h3>Shipping address:</h3>
+    <p>%s, %s<br>%s, %s</p>
+
+    <h3>Items:</h3>
+    <table style="width:100%%; border-collapse: collapse;">
+      <thead>
+        <tr>
+          <th style="text-align: left; padding: 8px; border: 1px solid #ddd;">Item</th>
+          <th style="text-align: left; padding: 8px; border: 1px solid #ddd;">Size</th>
+          <th style="text-align: left; padding: 8px; border: 1px solid #ddd;">Quantity</th>
+          <th style="text-align: right; padding: 8px; border: 1px solid #ddd;">Price</th>
+        </tr>
+      </thead>
+      <tbody>
+        %s
+      </tbody>
+    </table>
+
+    <h4>Total: $%.2f</h4>
+
+    <p>Thank you for shopping with us!</p>
+    <p>Best regards,<br>Sockify team</p>
+  </body>
+</html>`,
+		order.InvoiceNumber,
+		order.Status,
+		order.CreatedAt,
+		order.Address.Street,
+		aptUnit,
+		order.Address.State,
+		order.Address.Zipcode,
+		formatItemsHTML(order.Items),
+		order.Total,
+	)
+
+	return plainText, htmlContent
+}
+
+func formatItemsPlain(items []types.OrderItem) string {
+	result := make([]string, 0)
+	for _, item := range items {
+		result = append(result, fmt.Sprintf("- %s (Size: %s) x%d - $%.2f\n", item.Name, item.Size, item.Quantity, item.Price))
+	}
+	return strings.Join(result, "")
+}
+
+func formatItemsHTML(items []types.OrderItem) string {
+	result := make([]string, 0)
+	for _, item := range items {
+		result = append(result, fmt.Sprintf(`<tr>
+          <td style="padding: 8px; border: 1px solid #ddd;">%s</td>
+          <td style="padding: 8px; border: 1px solid #ddd;">%s</td>
+          <td style="padding: 8px; border: 1px solid #ddd;">%d</td>
+          <td style="padding: 8px; border: 1px solid #ddd; text-align: right;">$%.2f</td>
+        </tr>`, item.Name, item.Size, item.Quantity, item.Price))
+	}
+	return strings.Join(result, "")
+}

--- a/api/services/email/templates/order_confirmation.go
+++ b/api/services/email/templates/order_confirmation.go
@@ -10,7 +10,7 @@ import (
 func CreateOrderConfirmationTemplate(order types.OrderConfirmation) (plainText string, htmlContent string) {
 	// TODO: need to add "city" to address
 	aptUnit := ""
-	if order.Address.AptUnit != nil {
+	if order.Address.AptUnit != nil && len(*order.Address.AptUnit) > 0 {
 		aptUnit = ", " + *order.Address.AptUnit
 	}
 
@@ -53,13 +53,13 @@ func CreateOrderConfirmationTemplate(order types.OrderConfirmation) (plainText s
 	htmlContent = fmt.Sprintf(`<html>
   <body>
     <h2>Thank you for your order!</h2>
-    <h4>DISCLAIMER: this is a test confirmation, the order won't be fulfilled!</h4>
+    <em>DISCLAIMER: this is a test confirmation, the order won't be fulfilled!</em>
     <p><strong>Invoice #:</strong> %s</p>
     <p><strong>Status:</strong> %s</p>
     <p><strong>Date:</strong> %s</p>
 
     <h3>Shipping address:</h3>
-    <p>%s, %s<br>%s, %s</p>
+    <p>%s%s<br>%s, %s</p>
 
     <h3>Items:</h3>
     <table style="width:100%%; border-collapse: collapse;">

--- a/api/utils/constants.go
+++ b/api/utils/constants.go
@@ -1,0 +1,6 @@
+package utils
+
+const (
+	EmailSenderName     = "Sockify"
+	NoReplyEmailAddress = "snune085@fiu.edu"
+)


### PR DESCRIPTION
## Description

Users will now be able to an email confirmation when they make an order. For now, the email is sent everytime the user ends in the `/cart/checkout/order-confirmation` page (meaning if they refresh the page, the same email will be sent out again). Of course, not ideal but it's fine for the MVP.

## Changes

- Creates the `email` service in the backend
- Integrates the `Send Grid` email client service (https://app.sendgrid.com/)
- Adds the `SENDGRID_API_KEY` to the `environment` in `railway` both `production` and `develop`

## Screenshots/demo

<img width="1116" alt="Screenshot 2024-11-11 at 10 56 59 AM" src="https://github.com/user-attachments/assets/e37f812d-3023-4540-9e3b-1c468c7303af">

## Related issues

Closes #119